### PR TITLE
Add Security Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ The following optional inputs:
 | --- | --- |
 | `cosign-release` | Cosign release version that the user wants to use instead of the default. |
 
+## Security
+
+Should you discover any security issues, please refer to sigstores [security
+process](https://github.com/sigstore/community/blob/main/SECURITY.md)


### PR DESCRIPTION
I will perform a 'lazy consensus' and self-merge this if not
approved by 07/05/2021

The idea is to point to one file in community where we can
add to the security handling process without updating all repos.

Signed-off-by: Luke Hinds <lhinds@redhat.com>
