### PR TITLE
lets use sha256sum instead of shasum -a 256

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,8 @@ runs:
     - run: |
         bootstrap_version='v1.0.0'
         expected_bootstrap_version_digest='e36a05ab402bfee5463ad4752d8dc2941204c7b01a9a9931f921e91d94ba2484'
-        curl -L https://storage.googleapis.com/cosign-releases/v1.0.0/cosign-linux-amd64 -o cosign
-        shaBootstrap=$(shasum -a 256 cosign | cut -d' ' -f1);
+        curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/cosign-linux-amd64 -o cosign
+        shaBootstrap=$(sha256sum cosign | cut -d' ' -f1);
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then exit 1; fi
         chmod +x cosign
 
@@ -35,11 +35,11 @@ runs:
 
         # Download custom cosign
         if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-          curl -L https://storage.googleapis.com/cosign-releases/v0.6.0/cosign_linux_amd64 -o cosign_${{ inputs.cosign-release }}
+          curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/cosign_linux_amd64 -o cosign_${{ inputs.cosign-release }}
         else
           curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/cosign-linux-amd64 -o cosign_${{ inputs.cosign-release }}
         fi
-        shaCustom=$(shasum -a 256 cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
+        shaCustom=$(sha256sum cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
 
         # same hash means it is the same release
         if [[ $shaCustom != $shaBootstrap ]];
@@ -48,7 +48,7 @@ runs:
             # v0.6.0's linux release has a dependency on `libpcsclite1`
             sudo apt-get update -q
             sudo apt-get install -yq libpcsclite1
-            curl -L https://github.com/sigstore/cosign/releases/download/v0.6.0/cosign_linux_amd64_0.6.0_linux_amd64.sig -o cosign-linux-amd64.sig
+            curl -L https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/cosign_linux_amd64_0.6.0_linux_amd64.sig -o cosign-linux-amd64.sig
           else
             curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/cosign-linux-amd64.sig
           fi


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

I tested it, you can see the results from the link below:
> https://github.com/developer-guy/cosign-installer/actions/runs/1142685296
