### PR TITLE
codeowners: add github users to make explicity the team members

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,8 @@
 @sigstore/cosign-installer-codeowners
+
+# The CODEOWNERS are managed via a GitHub team, but the current list is (alphabetically):
+# cpanato
+# dekakgaijin
+# dlorenc
+# lukehinds
+# mbestavros


### PR DESCRIPTION
- codeowners: add github users to make explicity the team members
- ~~cosign: update default cosign to v1.1.0 release~~ Updated in this PR: https://github.com/sigstore/cosign-installer/pull/18