### PR TITLE
cleanup files after validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,3 +74,5 @@ runs:
       shell: bash
     - run: mkdir -p $HOME/.cosign && mv cosign $HOME/.cosign/ && echo "$HOME/.cosign" >> $GITHUB_PATH
       shell: bash
+    - run: rm -f *.pub
+      shell: bash


### PR DESCRIPTION

cleanup files after validation, those are not needed after the install

Fixes: https://github.com/sigstore/cosign-installer/issues/21