### PR TITLE
adding permission scope

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,9 +1,21 @@
 name: test-cosign
+
 on: [pull_request]
 
 jobs:
   test_cosign_action:
     runs-on: ubuntu-latest
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
     name: Install Cosign and test presence in path
     steps:
     - uses: actions/checkout@v2
@@ -22,6 +34,17 @@ jobs:
 
   test_existing_release_action:
     runs-on: ubuntu-latest
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
     name: Install existing release of Cosign and test presence in path
     steps:
     - uses: actions/checkout@v2
@@ -40,6 +63,17 @@ jobs:
 
   test_cosign_action_custom:
     runs-on: ubuntu-latest
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
     name: Install Custom Cosign and test presence in path
     steps:
     - uses: actions/checkout@v2
@@ -60,6 +94,17 @@ jobs:
 
   test_cosign_action_0_6_0:
     runs-on: ubuntu-latest
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
     name: Install Cosign v0.6.0 and test presence in path
     steps:
     - uses: actions/checkout@v2
@@ -80,6 +125,17 @@ jobs:
 
   test_cosign_action_0_6_0_with_pre_installed_libpcsclite1_package:
     runs-on: ubuntu-latest
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
     name: Install Cosign v0.6.0 and test presence in path with pre installed libpcsclite1 package
     steps:
     - uses: actions/checkout@v2
@@ -104,6 +160,17 @@ jobs:
 
   test_cosign_action_wrong:
     runs-on: ubuntu-latest
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
     name: Try to install a wrong Cosign
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Example using a pinned version:
 jobs:
   test_cosign_action:
     runs-on: ubuntu-latest
+
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
+
     name: Install Cosign and test presence in path
     steps:
       - name: Install Cosign
@@ -38,12 +51,79 @@ Example using the default version:
 jobs:
   test_cosign_action:
     runs-on: ubuntu-latest
+
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
+
     name: Install Cosign and test presence in path
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
       - name: Check install!
         run: cosign version
+```
+
+This action does not need any GitHub permission to run, however, if your workflow needs to update, create or perform any
+action against your repository, then you should change the scope of the permission appropriately.
+
+For example, if you are using the `gcr.io` as your registry to push the images you will need to give the `write` permission
+to the `packages` scope.
+
+Example of a simple workflow:
+
+```yaml
+jobs:
+  test_cosign_action:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: write
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
+
+    name: Install Cosign and test presence in path
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and Push container images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/sigstore/sample-honk:${{ github.sha }}
+
+      - name: Sign image
+        run: |
+          cosign sign -key my_cosign.key ghcr.io/sigstore/sample-honk:${{ github.sha }}
 ```
 
 ### Optional Inputs


### PR DESCRIPTION
#### Summary
Add permission scope documentation for the GH Action and also set those in the CI

#### Ticket Link

Fixes: https://github.com/sigstore/cosign-installer/issues/26

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
document permission scopes
```
