### PR TITLE
upgrade cosign to 1.3.1 and prepare for the gh action release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ For available `cosign` releases, see https://github.com/sigstore/cosign/releases
 Add the following entry to your Github workflow YAML file:
 
 ```yaml
-uses: sigstore/cosign-installer@main
+uses: sigstore/cosign-installer@v1.3.1
 with:
-  cosign-release: 'v1.3.0' # optional
+  cosign-release: 'v1.3.1' # optional
 ```
 
 Example using a pinned version:
@@ -40,7 +40,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.3.0'
+          cosign-release: 'v1.3.1'
       - name: Check install!
         run: cosign version
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   cosign-release:
     description: 'Cosign release version to use in the actions.'
     required: false
-    default: 'v1.3.0'
+    default: 'v1.3.1'
 runs:
   using: "composite"
   steps:
@@ -20,8 +20,8 @@ runs:
         mkdir -p $HOME/.cosign
         pushd $HOME/.cosign
 
-        bootstrap_version='v1.3.0'
-        expected_bootstrap_version_digest='9604a5eb171748113f92a67495556007dde6f45804f0b38d3e55c3bc7e151774'
+        bootstrap_version='v1.3.1'
+        expected_bootstrap_version_digest='1227b270e5d7d21d09469253cce17b72a14f6b7c9036dfc09698c853b31e8fc8'
         curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/cosign-linux-amd64 -o cosign
         shaBootstrap=$(sha256sum cosign | cut -d' ' -f1);
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then exit 1; fi


### PR DESCRIPTION
#### Summary
- upgrade cosign to 1.3.1 and prepare for the gh action release

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
upgrade cosign to 1.3.1 and prepare for the gh action release
```
