### PR TITLE
Allow setting a custom install dir

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -179,3 +179,41 @@ jobs:
       with:
         cosign-release: 'honk'
       continue-on-error: true
+  test_cosign_action_custom_dir:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
+    name: Install Custom Cosign and test presence in path
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Cosign
+        uses: ./
+        with:
+          install-dir: "$HOME/.cosigntest"
+      - name: Check install!
+        run: cosign version
+      - name: Check install dir!
+        run: |
+          if [[ $(dirname `which cosign`) == "$HOME/.cosigntest" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+      - name: Check root directory
+        run: |
+          if [[ $(git diff --stat) != '' ]]; then
+            echo 'should be clean'
+            exit 1
+          else
+            exit 0
+          fi
+

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Cosign release version to use in the actions.'
     required: false
     default: 'v1.4.1'
+  install-dir:
+    description: 'Where to install the cosign binary'
+    required: false
+    default: '$HOME/.cosign'
 runs:
   using: "composite"
   steps:
@@ -17,8 +21,8 @@ runs:
     - run: |
         trap "popd" EXIT
 
-        mkdir -p $HOME/.cosign
-        pushd $HOME/.cosign
+        mkdir -p ${{ inputs.install-dir }}
+        pushd ${{ inputs.install-dir }}
 
         bootstrap_version='v1.4.1'
         expected_bootstrap_version_digest='08ba779a4e6ff827079abed1a6d1f0a0d9e48aea21f520ddeb42ff912f59d268'
@@ -80,5 +84,5 @@ runs:
           chmod +x cosign
         fi
       shell: bash
-    - run:  echo "$HOME/.cosign" >> $GITHUB_PATH
+    - run:  echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
       shell: bash


### PR DESCRIPTION
#### Summary

Allows setting a custom dir for binary install

#### Ticket Link

Fixes #36 

#### Release Note

-->
```release-note
### Optional Inputs
The following optional inputs:

| Input | Description |
| --- | --- |
| `cosign-release` | `cosign` version to use instead of the default. |
| `install-dir` | `target dir to install `cosign` at. |

```
