### PR TITLE
add multiarch support for both linux and macOS runners

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -36,10 +36,11 @@ jobs:
         fi
 
   test_existing_release_action:
+    # this does not run on macOS as the support for multi-arch was not added yet
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
     permissions:
       actions: none
       checks: none
@@ -136,10 +137,11 @@ jobs:
         fi
 
   test_cosign_action_0_6_0_with_pre_installed_libpcsclite1_package:
+    # this test is specifically for linux and pcsclite1 dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
     permissions:
       actions: none
       checks: none

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -4,7 +4,10 @@ on: [pull_request]
 
 jobs:
   test_cosign_action:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     permissions:
       actions: none
       checks: none
@@ -33,7 +36,10 @@ jobs:
         fi
 
   test_existing_release_action:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     permissions:
       actions: none
       checks: none
@@ -62,7 +68,10 @@ jobs:
         fi
 
   test_cosign_action_custom:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     permissions:
       actions: none
       checks: none
@@ -93,7 +102,10 @@ jobs:
         fi
 
   test_cosign_action_0_6_0:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     permissions:
       actions: none
       checks: none
@@ -124,7 +136,10 @@ jobs:
         fi
 
   test_cosign_action_0_6_0_with_pre_installed_libpcsclite1_package:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     permissions:
       actions: none
       checks: none
@@ -159,7 +174,10 @@ jobs:
         fi
 
   test_cosign_action_wrong:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     permissions:
       actions: none
       checks: none
@@ -179,8 +197,12 @@ jobs:
       with:
         cosign-release: 'honk'
       continue-on-error: true
+
   test_cosign_action_custom_dir:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     permissions:
       actions: none
       checks: none

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ For available `cosign` releases, see https://github.com/sigstore/cosign/releases
 
 ## Usage
 
+This action currently supports both Linux and macOS runners (Windows support coming soon!)
+
 Add the following entry to your Github workflow YAML file:
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,7 @@ runs:
                 # v0.6.0 had different filename structures from all other releases
                 if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
                   desired_cosign_filename='cosign_linux_amd64'
+                  desired_cosign_v060_signature='cosign_linux_amd64_0.6.0_linux_amd64.sig'
                 fi
                 ;;
               
@@ -85,6 +86,7 @@ runs:
                 # v0.6.0 had different filename structures from all other releases
                 if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
                   desired_cosign_filename='cosign_darwin_amd64'
+                  desired_cosign_v060_signature='cosign_darwin_amd64_0.6.0_darwin_amd64.sig'
                 fi
                 ;;
               
@@ -95,6 +97,7 @@ runs:
                 # v0.6.0 had different filename structures from all other releases
                 if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
                   desired_cosign_filename='cosign_darwin_arm64'
+                  desired_cosign_v060_signature='cosign_darwin_arm64_0.6.0_darwin_arm64.sig'
                 fi
                 ;;
               
@@ -149,7 +152,11 @@ runs:
                  sudo apt-get install -yq libpcsclite1
             fi
           fi
-          curl -LO https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
+          if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
+            curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature}.sig -o ${desired_cosign_filename}.sig
+          else
+            curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
+          fi
 
           if [[ ${{ inputs.cosign-release }} < 'v0.6.0' ]]; then
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/.github/workflows/cosign.pub

--- a/action.yml
+++ b/action.yml
@@ -139,6 +139,7 @@ runs:
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/release/release-cosign.pub
           fi
 
+          set -x
           ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${bootstrap_filename}.sig cosign_${{ inputs.cosign-release }}
           if [[ $? != 0 ]]; then
             echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}' using release public key"

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ runs:
         bootstrap_linux_arm64_sha='b0c02b607e722b9d2b1807f6efb73042762e77391c51c8948710e7f571ceaa73'
         bootstrap_darwin_amd64_sha='0908ffd3ceea5534c27059e30276094d63ed9339c2bf75e38e3d88d0a34502f3'
         bootstrap_darwin_arm64_sha='f8162aba987e1afddb20a672e47fb070ec6bf1547f65f23159e0f4a61e4ea673'
+
         trap "popd" EXIT
 
         mkdir -p ${{ inputs.install-dir }}
@@ -38,17 +39,17 @@ runs:
             case ${{ runner.arch }} in
               X64)
                 bootstrap_filename='cosign-linux-amd64'
-                bootstrap_sha=$INPUT_BOOTSTRAP_LINUX_AMD64_SHA
+                bootstrap_sha=${bootstrap_linux_amd64_sha}
                 ;;
               
               ARM)
                 bootstrap_filename='cosign-linux-arm'
-                bootstrap_sha=$INPUT_BOOTSTRAP_LINUX_ARM_SHA
+                bootstrap_sha=${bootstrap_linux_arm_sha}
                 ;;
               
               ARM64)
                 bootstrap_filename='cosign-linux-arm64'
-                bootstrap_sha=$INPUT_BOOTSTRAP_LINUX_ARM64_SHA
+                bootstrap_sha=${bootstrap_linux_arm64_sha}
                 ;;
               
               *)
@@ -62,12 +63,12 @@ runs:
             case ${{ runner.arch }} in
               X64)
                 bootstrap_filename='cosign-darwin-amd64'
-                bootstrap_sha=$INPUT_BOOTSTRAP_DARWIN_AMD64_SHA
+                bootstrap_sha=${bootstrap_darwin_amd64_sha}
                 ;;
               
               ARM64)
                 bootstrap_filename='cosign-darwin-arm64'
-                bootstrap_sha=$INPUT_BOOTSTRAP_DARWIN_ARM64_SHA
+                bootstrap_sha=${bootstrap_darwin_arm64_sha}
                 ;;
               
               *)
@@ -78,9 +79,9 @@ runs:
             ;;
         esac
 
-        bootstrap_version=${INPUT_BOOTSTRAP_VERSION}
+        set -e
         expected_bootstrap_version_digest=${bootstrap_sha}
-        curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
+        curl -Lv https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
         shaBootstrap=$(sha256sum cosign | cut -d' ' -f1);
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
           echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}'"

--- a/action.yml
+++ b/action.yml
@@ -24,13 +24,9 @@ runs:
       run: |
         #!/bin/bash
         # cosign install script
-        BOLD='\e[1m'
-        RED='\e[31m'
-        GREEN='\e[32m'
-        DEF='\e[0m'
         shopt -s expand_aliases
-        alias log_info="echo -e \"${BOLD}${GREEN}INFO${DEF}:\""
-        alias log_error="echo -e \"${BOLD}${RED}ERROR${DEF}:\""
+        alias log_info="echo -e \"$(tput bold)$(tput setaf 2)INFO$(tput sgr0):\""
+        alias log_error="echo -e \"$(tput bold)$(tput setaf 1}ERROR$(tput sgr0):\""
         set -e
 
         bootstrap_version='v1.4.1'    

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
                 bootstrap_sha=${bootstrap_darwin_amd64_sha}
                 desired_cosign_filename='cosign-darwin-amd64'
                 # v0.6.0 had different filename structures from all other releases
-                if [[ ${{ inputs.cosign-release }} == 'v0.6.0']]; then
+                if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
                   desired_cosign_filename='cosign_darwin_amd64_0.6.0_darwin_amd64'
                 fi
                 ;;
@@ -93,7 +93,7 @@ runs:
                 bootstrap_sha=${bootstrap_darwin_arm64_sha}
                 desired_cosign_filename='cosign-darwin-arm64'
                 # v0.6.0 had different filename structures from all other releases
-                if [[ ${{ inputs.cosign-release }} == 'v0.6.0']]; then
+                if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
                   desired_cosign_filename='cosign_darwin_arm64_0.6.0_darwin_arm64'
                 fi
                 ;;

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
             fi
           fi
           if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-            curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature}.sig -o ${desired_cosign_filename}.sig
+            curl -L https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature} -o ${desired_cosign_filename}.sig
           else
             curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
           fi

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ runs:
         RED='\e[31m'
         GREEN='\e[32m'
         DEF='\e[0m'
+        shopt -s expand_aliases
         alias log_info="echo -e \"${BOLD}${GREEN}INFO${DEF}:\""
         alias log_error="echo -e \"${BOLD}${RED}ERROR${DEF}:\""
         set -e

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,7 @@ runs:
 
         case ${{ runner.os }} in
           Linux)
+            shaprog='sha256sum'
             case ${{ runner.arch }} in
               X64)
                 bootstrap_filename='cosign-linux-amd64'
@@ -60,6 +61,7 @@ runs:
             ;;
           
           macOS)
+            shaprog='shasum -a256'
             case ${{ runner.arch }} in
               X64)
                 bootstrap_filename='cosign-darwin-amd64'
@@ -77,7 +79,6 @@ runs:
                 ;;
             esac
             ;;
-
           *)
             echo "ERROR: unsupported architecture $arch"
             exit 1
@@ -87,7 +88,7 @@ runs:
         set -e
         expected_bootstrap_version_digest=${bootstrap_sha}
         curl -Lv https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
-        shaBootstrap=${{ hashfiles('cosign') }}
+        shaBootstrap=$(${shaprog} cosign | cut -d' ' -f1);
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
           echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}'"
           exit 1
@@ -111,7 +112,7 @@ runs:
         else
           curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${bootstrap_filename} -o cosign_${{ inputs.cosign-release }}
         fi
-        shaCustom=${{ hashfiles('cosign_${{ inputs.cosign-release }}')}}
+        shaCustom=$(${shaprog} cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
 
         # same hash means it is the same release
         if [[ $shaCustom != $shaBootstrap ]];

--- a/action.yml
+++ b/action.yml
@@ -41,16 +41,31 @@ runs:
               X64)
                 bootstrap_filename='cosign-linux-amd64'
                 bootstrap_sha=${bootstrap_linux_amd64_sha}
+                desired_cosign_filename='cosign-linux-amd64'
+                # v0.6.0 had different filename structures from all other releases
+                if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
+                  desired_cosign_filename='cosign_linux_amd64_0.6.0_linux_amd64'
+                fi
                 ;;
               
               ARM)
                 bootstrap_filename='cosign-linux-arm'
                 bootstrap_sha=${bootstrap_linux_arm_sha}
+                desired_cosign_filename='cosign-linux-arm'
+                if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
+                  echo "ERROR: linux-arm build not available at v0.6.0"
+                  exit 1
+                fi
                 ;;
               
               ARM64)
                 bootstrap_filename='cosign-linux-arm64'
                 bootstrap_sha=${bootstrap_linux_arm64_sha}
+                desired_cosign_filename='cosign-linux-amd64'
+                if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
+                  echo "ERROR: linux-arm64 build not available at v0.6.0"
+                  exit 1
+                fi
                 ;;
               
               *)
@@ -66,11 +81,21 @@ runs:
               X64)
                 bootstrap_filename='cosign-darwin-amd64'
                 bootstrap_sha=${bootstrap_darwin_amd64_sha}
+                desired_cosign_filename='cosign-darwin-amd64'
+                # v0.6.0 had different filename structures from all other releases
+                if [[ ${{ inputs.cosign-release }} == 'v0.6.0']]; then
+                  desired_cosign_filename='cosign_darwin_amd64_0.6.0_darwin_amd64'
+                fi
                 ;;
               
               ARM64)
                 bootstrap_filename='cosign-darwin-arm64'
                 bootstrap_sha=${bootstrap_darwin_arm64_sha}
+                desired_cosign_filename='cosign-darwin-arm64'
+                # v0.6.0 had different filename structures from all other releases
+                if [[ ${{ inputs.cosign-release }} == 'v0.6.0']]; then
+                  desired_cosign_filename='cosign_darwin_arm64_0.6.0_darwin_arm64'
+                fi
                 ;;
               
               *)
@@ -85,6 +110,7 @@ runs:
             exit 1
             ;;
         esac
+        desired_cosign_signature='${desired_cosign_filename}.sig'
 
         expected_bootstrap_version_digest=${bootstrap_sha}
         curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
@@ -107,11 +133,7 @@ runs:
         fi
 
         # Download custom cosign
-        if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-          curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${bootstrap_filename} -o cosign_${{ inputs.cosign-release }}
-        else
-          curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${bootstrap_filename} -o cosign_${{ inputs.cosign-release }}
-        fi
+        curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename} -o cosign_${{ inputs.cosign-release }}
         shaCustom=$(${shaprog} cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
 
         # same hash means it is the same release
@@ -127,11 +149,8 @@ runs:
                  sudo apt-get update -q
                  sudo apt-get install -yq libpcsclite1
             fi
-            set -e
-            curl -L https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/cosign_linux_amd64_0.6.0_linux_amd64.sig -o ${bootstrap_filename}.sig
-          else
-            curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${bootstrap_filename}.sig
           fi
+          curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_signature}
 
           if [[ ${{ inputs.cosign-release }} < 'v0.6.0' ]]; then
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/.github/workflows/cosign.pub
@@ -140,7 +159,7 @@ runs:
           fi
 
           set -x
-          ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${bootstrap_filename}.sig cosign_${{ inputs.cosign-release }}
+          ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${desired_cosign_signature} cosign_${{ inputs.cosign-release }}
           if [[ $? != 0 ]]; then
             echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}' using release public key"
             exit 1

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,14 @@
 # action.yml
 name: install-cosign
-description: 'Install Cosign and put it on your path'
+author: sigstore
+description: 'Installs cosign and includes it in your path'
 branding:
   icon: 'package'
   color: 'blue'
 # This is pinned to the last major release, we have to bump it for each action version.
 inputs:
   cosign-release:
-    description: 'Cosign release version to use in the actions.'
+    description: 'cosign release version to be installed'
     required: false
     default: 'v1.4.1'
   install-dir:
@@ -18,19 +19,74 @@ runs:
   using: "composite"
   steps:
     # We verify the version against a SHA **in the published action itself**, not in the GCS bucket.
-    - run: |
+    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      shell: bash
+      with:
+        bootstrap_version: 'v1.4.1'    
+        bootstrap_linux_amd64_sha: '08ba779a4e6ff827079abed1a6d1f0a0d9e48aea21f520ddeb42ff912f59d268'
+        bootstrap_linux_arm_sha: 'd13f12dea3b65ec4bcd25fe23d35772f7b0b5997dba14947ce242e1260b3a15d'
+        bootstrap_linux_arm64_sha: 'b0c02b607e722b9d2b1807f6efb73042762e77391c51c8948710e7f571ceaa73'
+        bootstrap_darwin_amd64_sha: '0908ffd3ceea5534c27059e30276094d63ed9339c2bf75e38e3d88d0a34502f3'
+        bootstrap_darwin_arm64_sha: 'f8162aba987e1afddb20a672e47fb070ec6bf1547f65f23159e0f4a61e4ea673'
+      run: |
         trap "popd" EXIT
 
         mkdir -p ${{ inputs.install-dir }}
         pushd ${{ inputs.install-dir }}
 
-        echo ${{ runner.os }}
+        case ${{ runner.os }} in
+          Linux)
+            case ${{ runner.arch }} in
+              X64)
+                bootstrap_filename='cosign-linux-amd64'
+                bootstrap_sha=$INPUT_BOOTSTRAP_LINUX_AMD64_SHA
+                ;;
+              
+              ARM)
+                bootstrap_filename='cosign-linux-arm'
+                bootstrap_sha=$INPUT_BOOTSTRAP_LINUX_ARM_SHA
+                ;;
+              
+              ARM64)
+                bootstrap_filename='cosign-linux-arm64'
+                bootstrap_sha=$INPUT_BOOTSTRAP_LINUX_ARM64_SHA
+                ;;
+              
+              *)
+                echo "ERROR: unsupported architecture $arch"
+                exit 1
+                ;;
+            esac
+            ;;
+          
+          Darwin)
+            case ${{ runner.arch }} in
+              X64)
+                bootstrap_filename='cosign-darwin-amd64'
+                bootstrap_sha=$INPUT_BOOTSTRAP_DARWIN_AMD64_SHA
+                ;;
+              
+              ARM64)
+                bootstrap_filename='cosign-darwin-arm64'
+                bootstrap_sha=$INPUT_BOOTSTRAP_DARWIN_ARM64_SHA
+                ;;
+              
+              *)
+                echo "ERROR: unsupported architecture $arch"
+                exit 1
+                ;;
+            esac
+            ;;
+        esac
 
-        bootstrap_version='v1.4.1'
-        expected_bootstrap_version_digest='08ba779a4e6ff827079abed1a6d1f0a0d9e48aea21f520ddeb42ff912f59d268'
-        curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/cosign-linux-amd64 -o cosign
+        bootstrap_version=${INPUT_BOOTSTRAP_VERSION}
+        expected_bootstrap_version_digest=${bootstrap_sha}
+        curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
         shaBootstrap=$(sha256sum cosign | cut -d' ' -f1);
-        if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then exit 1; fi
+        if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
+          echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}'"
+          exit 1
+        fi
         chmod +x cosign
 
         # If the bootstrap and specified `cosign` releases are the same, we're done.
@@ -46,16 +102,16 @@ runs:
 
         # Download custom cosign
         if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-          curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/cosign_linux_amd64 -o cosign_${{ inputs.cosign-release }}
+          curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${bootstrap_filename} -o cosign_${{ inputs.cosign-release }}
         else
-          curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/cosign-linux-amd64 -o cosign_${{ inputs.cosign-release }}
+          curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${bootstrap_filename} -o cosign_${{ inputs.cosign-release }}
         fi
         shaCustom=$(sha256sum cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
 
         # same hash means it is the same release
         if [[ $shaCustom != $shaBootstrap ]];
         then
-          if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
+          if [[ ${{ inputs.cosign-release }} == 'v0.6.0' -a ${{ runner.os}} == 'Linux' ]]; then
             # v0.6.0's linux release has a dependency on `libpcsclite1`
             set +e
             sudo dpkg -s libpcsclite1
@@ -67,9 +123,9 @@ runs:
                  sudo apt-get install -yq libpcsclite1
             fi
             set -e
-            curl -L https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/cosign_linux_amd64_0.6.0_linux_amd64.sig -o cosign-linux-amd64.sig
+            curl -L https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/cosign_linux_amd64_0.6.0_linux_amd64.sig -o ${bootstrap_filename}.sig
           else
-            curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/cosign-linux-amd64.sig
+            curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${bootstrap_filename}.sig
           fi
 
           if [[ ${{ inputs.cosign-release }} < 'v0.6.0' ]]; then
@@ -78,13 +134,15 @@ runs:
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/release/release-cosign.pub
           fi
 
-          ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature cosign-linux-amd64.sig cosign_${{ inputs.cosign-release }}
-          if [[ $? != 0 ]]; then exit 1; fi
+          ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${bootstrap_filename}.sig cosign_${{ inputs.cosign-release }}
+          if [[ $? != 0 ]]; then
+            echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}' using release public key"
+            exit 1
+          fi
 
           rm cosign
           mv cosign_${{ inputs.cosign-release }} cosign
           chmod +x cosign
         fi
-      shell: bash
     - run:  echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -24,11 +24,12 @@ runs:
       run: |
         #!/bin/bash
         # cosign install script
-        RED='\033[0;31m'
-        GREEN='\033[0;32m'
-        NC='\033[0m' # No Color
-        alias log_info="echo -e "${GREEN}INFO${NC}:"
-        alias log_error="echo -e "${RED}ERROR${NC}:"
+        BOLD='\e[1m'
+        RED='\e[31m'
+        GREEN='\e[32m'
+        DEF='\e[0m'
+        alias log_info="echo -e \"${BOLD}${GREEN}INFO${DEF}:\""
+        alias log_error="echo -e \"${BOLD}${RED}ERROR${DEF}:\""
         set -e
 
         bootstrap_version='v1.4.1'    

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
             esac
             ;;
           
-          Darwin)
+          macOS)
             case ${{ runner.arch }} in
               X64)
                 bootstrap_filename='cosign-darwin-amd64'
@@ -76,6 +76,11 @@ runs:
                 exit 1
                 ;;
             esac
+            ;;
+
+          *)
+            echo "ERROR: unsupported architecture $arch"
+            exit 1
             ;;
         esac
 

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
 
         # same hash means it is the same release
         if [[ $shaCustom != $shaBootstrap ]]; then
-          if [[ ${{ inputs.cosign-release }} == 'v0.6.0' -a ${{ runner.os }} == 'Linux' ]]; then
+          if [[ ${{ inputs.cosign-release }} == 'v0.6.0' && ${{ runner.os }} == 'Linux' ]]; then
             # v0.6.0's linux release has a dependency on `libpcsclite1`
             set +e
             sudo dpkg -s libpcsclite1

--- a/action.yml
+++ b/action.yml
@@ -21,14 +21,13 @@ runs:
     # We verify the version against a SHA **in the published action itself**, not in the GCS bucket.
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       shell: bash
-      with:
-        bootstrap_version: 'v1.4.1'    
-        bootstrap_linux_amd64_sha: '08ba779a4e6ff827079abed1a6d1f0a0d9e48aea21f520ddeb42ff912f59d268'
-        bootstrap_linux_arm_sha: 'd13f12dea3b65ec4bcd25fe23d35772f7b0b5997dba14947ce242e1260b3a15d'
-        bootstrap_linux_arm64_sha: 'b0c02b607e722b9d2b1807f6efb73042762e77391c51c8948710e7f571ceaa73'
-        bootstrap_darwin_amd64_sha: '0908ffd3ceea5534c27059e30276094d63ed9339c2bf75e38e3d88d0a34502f3'
-        bootstrap_darwin_arm64_sha: 'f8162aba987e1afddb20a672e47fb070ec6bf1547f65f23159e0f4a61e4ea673'
       run: |
+        bootstrap_version='v1.4.1'    
+        bootstrap_linux_amd64_sha='08ba779a4e6ff827079abed1a6d1f0a0d9e48aea21f520ddeb42ff912f59d268'
+        bootstrap_linux_arm_sha='d13f12dea3b65ec4bcd25fe23d35772f7b0b5997dba14947ce242e1260b3a15d'
+        bootstrap_linux_arm64_sha='b0c02b607e722b9d2b1807f6efb73042762e77391c51c8948710e7f571ceaa73'
+        bootstrap_darwin_amd64_sha='0908ffd3ceea5534c27059e30276094d63ed9339c2bf75e38e3d88d0a34502f3'
+        bootstrap_darwin_arm64_sha='f8162aba987e1afddb20a672e47fb070ec6bf1547f65f23159e0f4a61e4ea673'
         trap "popd" EXIT
 
         mkdir -p ${{ inputs.install-dir }}

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,13 @@ runs:
         #!/bin/bash
         # cosign install script
         shopt -s expand_aliases
-        alias log_info="echo -e \"$(tput bold)$(tput setaf 2)INFO$(tput sgr0):\""
-        alias log_error="echo -e \"$(tput bold)$(tput setaf 1}ERROR$(tput sgr0):\""
+        if [ -z "$NO_COLOR" ]; then
+          alias log_info="echo -e \"\033[1;32mINFO\033[0m:\""
+          alias log_error="echo -e \"\033[1;31mERROR\033[0m:\""
+        else
+          alias log_info="echo \"INFO:\""
+          alias log_error="echo \"ERROR:\""
+        fi
         set -e
 
         bootstrap_version='v1.4.1'    

--- a/action.yml
+++ b/action.yml
@@ -120,9 +120,8 @@ runs:
 
         expected_bootstrap_version_digest=${bootstrap_sha}
         echo "INFO: Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed..."
-        set +x
+        echo :      https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename}"
         curl -sL https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
-        set -x
         shaBootstrap=$(${shaprog} cosign | cut -d' ' -f1);
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
           echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}'"
@@ -146,9 +145,8 @@ runs:
 
         # Download custom cosign
         echo "INFO: Downloading platform-specific version '${{ inputs.cosign-release }}' of cosign..."
-        set +x
+        echo"       https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename}"
         curl -sL https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename} -o cosign_${{ inputs.cosign-release }}
-        set -x
         shaCustom=$(${shaprog} cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
 
         # same hash means it is the same release
@@ -168,13 +166,13 @@ runs:
           fi
 
           echo "INFO: Downloading detached signature for platform-specific '${{ inputs.cosign-release }}' of cosign..."
-          set +x
           if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
+            echo "      https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature}"
             curl -sL https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature} -o ${desired_cosign_filename}.sig
           else
+            echo "      https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig"
             curl -sLO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
           fi
-          set -x
 
           if [[ ${{ inputs.cosign-release }} < 'v0.6.0' ]]; then
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/.github/workflows/cosign.pub
@@ -188,6 +186,8 @@ runs:
           rm cosign
           mv cosign_${{ inputs.cosign-release }} cosign
           chmod +x cosign
-          echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
           echo "INFO: Installation complete!"
         fi
+    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      run:  echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,7 @@ runs:
 
         expected_bootstrap_version_digest=${bootstrap_sha}
         echo "INFO: Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed..."
-        echo :      https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename}"
+        echo "      https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename}"
         curl -sL https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
         shaBootstrap=$(${shaprog} cosign | cut -d' ' -f1);
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
@@ -145,7 +145,7 @@ runs:
 
         # Download custom cosign
         echo "INFO: Downloading platform-specific version '${{ inputs.cosign-release }}' of cosign..."
-        echo"       https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename}"
+        echo "      https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename}"
         curl -sL https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename} -o cosign_${{ inputs.cosign-release }}
         shaCustom=$(${shaprog} cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ runs:
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       shell: bash
       run: |
+        #!/bin/bash
+        # cosign install script
+        set -e
+
         bootstrap_version='v1.4.1'    
         bootstrap_linux_amd64_sha='08ba779a4e6ff827079abed1a6d1f0a0d9e48aea21f520ddeb42ff912f59d268'
         bootstrap_linux_arm_sha='d13f12dea3b65ec4bcd25fe23d35772f7b0b5997dba14947ce242e1260b3a15d'
@@ -32,7 +36,7 @@ runs:
         trap "popd" EXIT
 
         mkdir -p ${{ inputs.install-dir }}
-        pushd ${{ inputs.install-dir }}
+        pushd ${{ inputs.install-dir }} > /dev/null
 
         case ${{ runner.os }} in
           Linux)
@@ -115,7 +119,10 @@ runs:
         esac
 
         expected_bootstrap_version_digest=${bootstrap_sha}
-        curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
+        echo "INFO: Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed..."
+        set +x
+        curl -sL https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
+        set -x
         shaBootstrap=$(${shaprog} cosign | cut -d' ' -f1);
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
           echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}'"
@@ -124,18 +131,24 @@ runs:
         chmod +x cosign
 
         # If the bootstrap and specified `cosign` releases are the same, we're done.
-        if [[ ${{ inputs.cosign-release }} == ${bootstrap_version} ]]; then exit 0; fi
+        if [[ ${{ inputs.cosign-release }} == ${bootstrap_version} ]]; then
+          echo "INFO: bootstrap version successfully verified and matches requested version so nothing else to do"
+          exit 0
+        fi
 
         semver='^v([0-9]+\.){0,2}(\*|[0-9]+)$'
         if [[ ${{ inputs.cosign-release }} =~ $semver ]]; then
-          echo "INFO: Custom Cosign Version ${{ inputs.cosign-release }}"
+          echo "INFO: Custom cosign version '${{ inputs.cosign-release }}' requested"
         else
-          echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}'"
+          echo "ERROR: Unable to validate requested cosign version: '${{ inputs.cosign-release }}'"
           exit 1
         fi
 
         # Download custom cosign
-        curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename} -o cosign_${{ inputs.cosign-release }}
+        echo "INFO: Downloading platform-specific version '${{ inputs.cosign-release }}' of cosign..."
+        set +x
+        curl -sL https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename} -o cosign_${{ inputs.cosign-release }}
+        set -x
         shaCustom=$(${shaprog} cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
 
         # same hash means it is the same release
@@ -151,12 +164,17 @@ runs:
                  sudo apt-get update -q
                  sudo apt-get install -yq libpcsclite1
             fi
+            set -e
           fi
+
+          echo "INFO: Downloading detached signature for platform-specific '${{ inputs.cosign-release }}' of cosign..."
+          set +x
           if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-            curl -L https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature} -o ${desired_cosign_filename}.sig
+            curl -sL https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature} -o ${desired_cosign_filename}.sig
           else
-            curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
+            curl -sLO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
           fi
+          set -x
 
           if [[ ${{ inputs.cosign-release }} < 'v0.6.0' ]]; then
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/.github/workflows/cosign.pub
@@ -164,17 +182,12 @@ runs:
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/release/release-cosign.pub
           fi
 
-          set -x
+          echo "INFO: Using bootstrap cosign to verify signature of desired cosign version"
           ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${desired_cosign_filename}.sig cosign_${{ inputs.cosign-release }}
-          if [[ $? != 0 ]]; then
-            echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}' using release public key"
-            exit 1
-          fi
 
           rm cosign
           mv cosign_${{ inputs.cosign-release }} cosign
           chmod +x cosign
+          echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
+          echo "INFO: Installation complete!"
         fi
-    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      run:  echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
-      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,6 @@ runs:
             exit 1
             ;;
         esac
-        desired_cosign_signature='${desired_cosign_filename}.sig'
 
         expected_bootstrap_version_digest=${bootstrap_sha}
         curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
@@ -159,7 +158,7 @@ runs:
           fi
 
           set -x
-          ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${desired_cosign_signature} cosign_${{ inputs.cosign-release }}
+          ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${desired_cosign_filename}.sig cosign_${{ inputs.cosign-release }}
           if [[ $? != 0 ]]; then
             echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}' using release public key"
             exit 1

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 # action.yml
-name: install-cosign
+name: cosign-installer
 author: sigstore
 description: 'Installs cosign and includes it in your path'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
         set -e
         expected_bootstrap_version_digest=${bootstrap_sha}
         curl -Lv https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
-        shaBootstrap=$(sha256sum cosign | cut -d' ' -f1);
+        shaBootstrap=${{ hashfiles('cosign') }}
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
           echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}'"
           exit 1
@@ -106,7 +106,7 @@ runs:
         else
           curl -L https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${bootstrap_filename} -o cosign_${{ inputs.cosign-release }}
         fi
-        shaCustom=$(sha256sum cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
+        shaCustom=${{ hashfiles('cosign_${{ inputs.cosign-release }}')}}
 
         # same hash means it is the same release
         if [[ $shaCustom != $shaBootstrap ]];

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,8 @@ runs:
         mkdir -p ${{ inputs.install-dir }}
         pushd ${{ inputs.install-dir }}
 
+        echo ${{ runner.os }}
+
         bootstrap_version='v1.4.1'
         expected_bootstrap_version_digest='08ba779a4e6ff827079abed1a6d1f0a0d9e48aea21f520ddeb42ff912f59d268'
         curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/cosign-linux-amd64 -o cosign

--- a/action.yml
+++ b/action.yml
@@ -86,9 +86,8 @@ runs:
             ;;
         esac
 
-        set -e
         expected_bootstrap_version_digest=${bootstrap_sha}
-        curl -Lv https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
+        curl -L https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
         shaBootstrap=$(${shaprog} cosign | cut -d' ' -f1);
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
           echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}'"

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
                 desired_cosign_filename='cosign-linux-amd64'
                 # v0.6.0 had different filename structures from all other releases
                 if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-                  desired_cosign_filename='cosign_linux_amd64_0.6.0_linux_amd64'
+                  desired_cosign_filename='cosign_linux_amd64'
                 fi
                 ;;
               
@@ -84,7 +84,7 @@ runs:
                 desired_cosign_filename='cosign-darwin-amd64'
                 # v0.6.0 had different filename structures from all other releases
                 if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-                  desired_cosign_filename='cosign_darwin_amd64_0.6.0_darwin_amd64'
+                  desired_cosign_filename='cosign_darwin_amd64'
                 fi
                 ;;
               
@@ -94,7 +94,7 @@ runs:
                 desired_cosign_filename='cosign-darwin-arm64'
                 # v0.6.0 had different filename structures from all other releases
                 if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-                  desired_cosign_filename='cosign_darwin_arm64_0.6.0_darwin_arm64'
+                  desired_cosign_filename='cosign_darwin_arm64'
                 fi
                 ;;
               
@@ -149,7 +149,7 @@ runs:
                  sudo apt-get install -yq libpcsclite1
             fi
           fi
-          curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
+          curl -LO https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
 
           if [[ ${{ inputs.cosign-release }} < 'v0.6.0' ]]; then
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/.github/workflows/cosign.pub

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,11 @@ runs:
       run: |
         #!/bin/bash
         # cosign install script
+        RED='\033[0;31m'
+        GREEN='\033[0;32m'
+        NC='\033[0m' # No Color
+        alias log_info="echo -e "${GREEN}INFO${NC}:"
+        alias log_error="echo -e "${RED}ERROR${NC}:"
         set -e
 
         bootstrap_version='v1.4.1'    
@@ -58,7 +63,7 @@ runs:
                 bootstrap_sha=${bootstrap_linux_arm_sha}
                 desired_cosign_filename='cosign-linux-arm'
                 if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-                  echo "ERROR: linux-arm build not available at v0.6.0"
+                  log_error "linux-arm build not available at v0.6.0"
                   exit 1
                 fi
                 ;;
@@ -68,13 +73,13 @@ runs:
                 bootstrap_sha=${bootstrap_linux_arm64_sha}
                 desired_cosign_filename='cosign-linux-amd64'
                 if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-                  echo "ERROR: linux-arm64 build not available at v0.6.0"
+                  log_error "linux-arm64 build not available at v0.6.0"
                   exit 1
                 fi
                 ;;
               
               *)
-                echo "ERROR: unsupported architecture $arch"
+                log_error "unsupported architecture $arch"
                 exit 1
                 ;;
             esac
@@ -106,46 +111,44 @@ runs:
                 ;;
               
               *)
-                echo "ERROR: unsupported architecture $arch"
+                log_error "unsupported architecture $arch"
                 exit 1
                 ;;
             esac
             ;;
 
           *)
-            echo "ERROR: unsupported architecture $arch"
+            log_error "unsupported architecture $arch"
             exit 1
             ;;
         esac
 
         expected_bootstrap_version_digest=${bootstrap_sha}
-        echo "INFO: Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed..."
-        echo "      https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename}"
+        log_info "Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed...\n      https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename}"
         curl -sL https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
         shaBootstrap=$(${shaprog} cosign | cut -d' ' -f1);
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
-          echo "ERROR: Unable to validate cosign version: '${{ inputs.cosign-release }}'"
+          log_error "Unable to validate cosign version: '${{ inputs.cosign-release }}'"
           exit 1
         fi
         chmod +x cosign
 
         # If the bootstrap and specified `cosign` releases are the same, we're done.
         if [[ ${{ inputs.cosign-release }} == ${bootstrap_version} ]]; then
-          echo "INFO: bootstrap version successfully verified and matches requested version so nothing else to do"
+          log_info "bootstrap version successfully verified and matches requested version so nothing else to do"
           exit 0
         fi
 
         semver='^v([0-9]+\.){0,2}(\*|[0-9]+)$'
         if [[ ${{ inputs.cosign-release }} =~ $semver ]]; then
-          echo "INFO: Custom cosign version '${{ inputs.cosign-release }}' requested"
+          log_info "Custom cosign version '${{ inputs.cosign-release }}' requested"
         else
-          echo "ERROR: Unable to validate requested cosign version: '${{ inputs.cosign-release }}'"
+          log_error "Unable to validate requested cosign version: '${{ inputs.cosign-release }}'"
           exit 1
         fi
 
         # Download custom cosign
-        echo "INFO: Downloading platform-specific version '${{ inputs.cosign-release }}' of cosign..."
-        echo "      https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename}"
+        log_info "Downloading platform-specific version '${{ inputs.cosign-release }}' of cosign...\n      https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename}"
         curl -sL https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename} -o cosign_${{ inputs.cosign-release }}
         shaCustom=$(${shaprog} cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
 
@@ -153,24 +156,24 @@ runs:
         if [[ $shaCustom != $shaBootstrap ]]; then
           if [[ ${{ inputs.cosign-release }} == 'v0.6.0' && ${{ runner.os }} == 'Linux' ]]; then
             # v0.6.0's linux release has a dependency on `libpcsclite1`
+            log_info "Installing libpcsclite1 package if necessary..."
             set +e
             sudo dpkg -s libpcsclite1
             if [ $? -eq 0 ]; then
-                echo "INFO: libpcsclite1 package is already installed"
+                log_info "libpcsclite1 package is already installed"
             else
-                 echo "INFO: libpcsclite1 package is not installed, installing it now."
-                 sudo apt-get update -q
+                 log_info "libpcsclite1 package is not installed, installing it now."
+                 sudo apt-get update -q -q
                  sudo apt-get install -yq libpcsclite1
             fi
             set -e
           fi
 
-          echo "INFO: Downloading detached signature for platform-specific '${{ inputs.cosign-release }}' of cosign..."
           if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
-            echo "      https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature}"
+            log_info "Downloading detached signature for platform-specific '${{ inputs.cosign-release }}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature}"
             curl -sL https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature} -o ${desired_cosign_filename}.sig
           else
-            echo "      https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig"
+            log_info "Downloading detached signature for platform-specific '${{ inputs.cosign-release }}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig"
             curl -sLO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
           fi
 
@@ -180,13 +183,13 @@ runs:
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/release/release-cosign.pub
           fi
 
-          echo "INFO: Using bootstrap cosign to verify signature of desired cosign version"
+          log_info "Using bootstrap cosign to verify signature of desired cosign version"
           ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${desired_cosign_filename}.sig cosign_${{ inputs.cosign-release }}
 
           rm cosign
           mv cosign_${{ inputs.cosign-release }} cosign
           chmod +x cosign
-          echo "INFO: Installation complete!"
+          log_info "Installation complete!"
         fi
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       run:  echo "${{ inputs.install-dir }}" >> $GITHUB_PATH

--- a/action.yml
+++ b/action.yml
@@ -149,7 +149,7 @@ runs:
                  sudo apt-get install -yq libpcsclite1
             fi
           fi
-          curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_signature}
+          curl -LO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
 
           if [[ ${{ inputs.cosign-release }} < 'v0.6.0' ]]; then
             RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${{ inputs.cosign-release }}/.github/workflows/cosign.pub

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,7 @@ runs:
                 ;;
             esac
             ;;
+
           *)
             echo "ERROR: unsupported architecture $arch"
             exit 1
@@ -115,9 +116,8 @@ runs:
         shaCustom=$(${shaprog} cosign_${{ inputs.cosign-release }} | cut -d' ' -f1);
 
         # same hash means it is the same release
-        if [[ $shaCustom != $shaBootstrap ]];
-        then
-          if [[ ${{ inputs.cosign-release }} == 'v0.6.0' -a ${{ runner.os}} == 'Linux' ]]; then
+        if [[ $shaCustom != $shaBootstrap ]]; then
+          if [[ ${{ inputs.cosign-release }} == 'v0.6.0' -a ${{ runner.os }} == 'Linux' ]]; then
             # v0.6.0's linux release has a dependency on `libpcsclite1`
             set +e
             sudo dpkg -s libpcsclite1
@@ -150,5 +150,6 @@ runs:
           mv cosign_${{ inputs.cosign-release }} cosign
           chmod +x cosign
         fi
-    - run:  echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
+    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      run:  echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
       shell: bash


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
Adds support for `macOS` runners as well as different processor architectures for `linux` and `macOS`. I will add `windows` support under a different PR.

<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Part of #42

#### Release Note
* Added support for `macOS` runners 
* Added support for different processor architectures for `linux` and `macOS`
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
