### PR TITLE
docs: simplify permissions in workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,6 @@ jobs:
 
     permissions:
       actions: none
-      checks: none
-      contents: none
-      deployments: none
-      issues: none
-      packages: none
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
 
     name: Install Cosign and test presence in path
     steps:
@@ -56,15 +47,6 @@ jobs:
 
     permissions:
       actions: none
-      checks: none
-      contents: none
-      deployments: none
-      issues: none
-      packages: none
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
 
     name: Install Cosign and test presence in path
     steps:
@@ -88,16 +70,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      actions: none
-      checks: none
       contents: read
-      deployments: none
-      issues: none
       packages: write
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
       id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
 
     name: Install Cosign and test presence in path


### PR DESCRIPTION
#### Summary

Simplifies the `permissions` in sample workflows.

What we really want is `permissions: none-all`, but that doesn't exist. Instead, explicitly setting the permissions for any scope, sets the permissions for all other scopes to `none`[^1]

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

[^1]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions