### PR TITLE
docs: update permissions to use new none format

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,17 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-    permissions:
-      actions: none
-      checks: none
-      contents: none
-      deployments: none
-      issues: none
-      packages: none
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
+    permissions: {}
     name: Install Cosign and test presence in path
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
@@ -42,17 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-    permissions:
-      actions: none
-      checks: none
-      contents: none
-      deployments: none
-      issues: none
-      packages: none
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
+    permissions: {}
     name: Install existing release of Cosign and test presence in path
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3
@@ -74,17 +54,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-    permissions:
-      actions: none
-      checks: none
-      contents: none
-      deployments: none
-      issues: none
-      packages: none
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
+    permissions: {}
     name: Install Custom Cosign and test presence in path
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3
@@ -109,17 +79,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-    permissions:
-      actions: none
-      checks: none
-      contents: none
-      deployments: none
-      issues: none
-      packages: none
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
+    permissions: {}
     name: Install Cosign v0.6.0 and test presence in path
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3
@@ -145,17 +105,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-    permissions:
-      actions: none
-      checks: none
-      contents: none
-      deployments: none
-      issues: none
-      packages: none
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
+    permissions: {}
     name: Install Cosign v0.6.0 and test presence in path with pre installed libpcsclite1 package
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3
@@ -183,17 +133,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-    permissions:
-      actions: none
-      checks: none
-      contents: none
-      deployments: none
-      issues: none
-      packages: none
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
+    permissions: {}
     name: Try to install a wrong Cosign
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3
@@ -208,17 +148,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-    permissions:
-      actions: none
-      checks: none
-      contents: none
-      deployments: none
-      issues: none
-      packages: none
-      pull-requests: none
-      repository-projects: none
-      security-events: none
-      statuses: none
+    permissions: {}
     name: Install Custom Cosign and test presence in path
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3
@@ -249,17 +179,7 @@ jobs:
   # TODO: uncomment when we remove the replace int he cosign go.mod
   # test_cosign_with_go_install:
   #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: none
-  #     checks: none
-  #     contents: none
-  #     deployments: none
-  #     issues: none
-  #     packages: none
-  #     pull-requests: none
-  #     repository-projects: none
-  #     security-events: none
-  #     statuses: none
+  #   permissions: {}
   #   name: Try to install cosign with go
   #   steps:
   #   - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ jobs:
   test_cosign_action:
     runs-on: ubuntu-latest
 
-    permissions:
-      actions: none
+    permissions: {}
 
     name: Install Cosign and test presence in path
     steps:
@@ -45,8 +44,7 @@ jobs:
   test_cosign_action:
     runs-on: ubuntu-latest
 
-    permissions:
-      actions: none
+    permissions: {}
 
     name: Install Cosign and test presence in path
     steps:
@@ -65,8 +63,7 @@ jobs:
   test_cosign_action:
     runs-on: ubuntu-latest
 
-    permissions:
-      actions: none
+    permissions: {}
 
     name: Install Cosign via go install
     steps:


### PR DESCRIPTION
#### Summary

GitHub actions now has a 'none-all' shorthand[^1]

> You can use the following syntax to disable permissions for all of the available scopes:
> 
> ```
> permissions: {}
> 

This is the same behaviour as before, but is more intuitive than `actions: none`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```

[^1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions