### PR TITLE
`sudo` mv the cosign binary to the `install-dir`

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -160,20 +160,35 @@ jobs:
         run: cosign version
       - name: Check install dir!
         run: |
-          if [[ $(dirname `which cosign`) == "$HOME/.cosigntest" ]]; then
-            exit 0
-          else
-            exit 1
-          fi
+          [[ $(dirname "$(which cosign)") == "$HOME/.cosigntest" ]]
         shell: bash
       - name: Check root directory
         run: |
-          if [[ $(git diff --stat) != '' ]]; then
-            echo 'should be clean'
-            exit 1
-          else
-            exit 0
-          fi
+          [[ -z $(git diff --stat) ]]
+        shell: bash
+
+  test_cosign_action_custom_dir_root:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    permissions: {}
+    name: Install Custom Cosign and test presence in path with custom root dir
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3
+      - name: Install Cosign
+        uses: ./
+        with:
+          install-dir: /usr/bin
+      - name: Check install!
+        run: cosign version
+      - name: Check install dir!
+        run: |
+          [[ $(dirname "$(which cosign)") == /usr/bin ]]
+        shell: bash
+      - name: Check root directory
+        run: |
+          [[ -z $(git diff --stat) ]]
         shell: bash
 
   # test_cosign_with_go_install:

--- a/action.yml
+++ b/action.yml
@@ -171,15 +171,20 @@ runs:
             ;;
         esac
 
+        SUDO=
+        if command -v sudo >/dev/null; then
+            SUDO=sudo
+        fi
+
         expected_bootstrap_version_digest=${bootstrap_sha}
         log_info "Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed...\n      https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename}"
-        curl -sL https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o ${cosign_executable_name}
+        $SUDO curl -sL https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o ${cosign_executable_name}
         shaBootstrap=$(shaprog ${cosign_executable_name});
         if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
           log_error "Unable to validate cosign version: '${{ inputs.cosign-release }}'"
           exit 1
         fi
-        chmod +x ${cosign_executable_name}
+        $SUDO chmod +x ${cosign_executable_name}
 
         # If the bootstrap and specified `cosign` releases are the same, we're done.
         if [[ ${{ inputs.cosign-release }} == ${bootstrap_version} ]]; then
@@ -197,7 +202,7 @@ runs:
 
         # Download custom cosign
         log_info "Downloading platform-specific version '${{ inputs.cosign-release }}' of cosign...\n      https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename}"
-        curl -sL https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename} -o cosign_${{ inputs.cosign-release }}
+        $SUDO curl -sL https://storage.googleapis.com/cosign-releases/${{ inputs.cosign-release }}/${desired_cosign_filename} -o cosign_${{ inputs.cosign-release }}
         shaCustom=$(shaprog cosign_${{ inputs.cosign-release }});
 
         # same hash means it is the same release
@@ -206,23 +211,23 @@ runs:
             # v0.6.0's linux release has a dependency on `libpcsclite1`
             log_info "Installing libpcsclite1 package if necessary..."
             set +e
-            sudo dpkg -s libpcsclite1
+            $SUDO dpkg -s libpcsclite1
             if [ $? -eq 0 ]; then
                 log_info "libpcsclite1 package is already installed"
             else
                  log_info "libpcsclite1 package is not installed, installing it now."
-                 sudo apt-get update -q -q
-                 sudo apt-get install -yq libpcsclite1
+                 $SUDO apt-get update -q -q
+                 $SUDO apt-get install -yq libpcsclite1
             fi
             set -e
           fi
 
           if [[ ${{ inputs.cosign-release }} == 'v0.6.0' ]]; then
             log_info "Downloading detached signature for platform-specific '${{ inputs.cosign-release }}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature}"
-            curl -sL https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature} -o ${desired_cosign_filename}.sig
+            $SUDO curl -sL https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_v060_signature} -o ${desired_cosign_filename}.sig
           else
             log_info "Downloading detached signature for platform-specific '${{ inputs.cosign-release }}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig"
-            curl -sLO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
+            $SUDO curl -sLO https://github.com/sigstore/cosign/releases/download/${{ inputs.cosign-release }}/${desired_cosign_filename}.sig
           fi
 
           if [[ ${{ inputs.cosign-release }} < 'v0.6.0' ]]; then
@@ -234,9 +239,9 @@ runs:
           log_info "Using bootstrap cosign to verify signature of desired cosign version"
           ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${desired_cosign_filename}.sig cosign_${{ inputs.cosign-release }}
 
-          rm cosign
-          mv cosign_${{ inputs.cosign-release }} ${cosign_executable_name}
-          chmod +x ${cosign_executable_name}
+          $SUDO rm cosign
+          $SUDO mv cosign_${{ inputs.cosign-release }} ${cosign_executable_name}
+          $SUDO chmod +x ${cosign_executable_name}
           log_info "Installation complete!"
         fi
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}


### PR DESCRIPTION


#### Summary
We cannot use `install-dir`s like `/usr/bin/cosign` right now because
this would cause an permission denied error. To be able to use those
paths we have to run `mv` and `chmod` via root.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
None

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixed `install-dir` locations to work when they require root access (for example `/usr/bin/cosign`.
```
