### PR TITLE
add use-sudo optional parameter defaulting to false. Fixes: #85

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,6 +1,10 @@
 name: test-cosign
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
 
 jobs:
   test_cosign_action:
@@ -180,6 +184,7 @@ jobs:
         uses: ./
         with:
           install-dir: /usr/bin
+          use-sudo: true
       - name: Check install!
         run: cosign version
       - name: Check install dir!

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The following optional inputs:
 | --- | --- |
 | `cosign-release` | `cosign` version to use instead of the default. |
 | `install-dir` | directory to place the `cosign` binary into instead of the default (`$HOME/.cosign`). |
+| `use-sudo` | set to `true` if `install-dir` location requires sudo privs. Defaults to false. |
 
 ## Security
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Where to install the cosign binary'
     required: false
     default: '$HOME/.cosign'
+  use-sudo:
+    description: 'set to true if install-dir location requires sudo privs'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -172,8 +176,8 @@ runs:
         esac
 
         SUDO=
-        if command -v sudo >/dev/null; then
-            SUDO=sudo
+        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
+          SUDO=sudo
         fi
 
         expected_bootstrap_version_digest=${bootstrap_sha}
@@ -211,13 +215,13 @@ runs:
             # v0.6.0's linux release has a dependency on `libpcsclite1`
             log_info "Installing libpcsclite1 package if necessary..."
             set +e
-            $SUDO dpkg -s libpcsclite1
+            sudo dpkg -s libpcsclite1
             if [ $? -eq 0 ]; then
                 log_info "libpcsclite1 package is already installed"
             else
                  log_info "libpcsclite1 package is not installed, installing it now."
-                 $SUDO apt-get update -q -q
-                 $SUDO apt-get install -yq libpcsclite1
+                 sudo apt-get update -q -q
+                 sudo apt-get install -yq libpcsclite1
             fi
             set -e
           fi


### PR DESCRIPTION
#### Summary
Adds optional input `use-sudo` that can be set to `true` in the case that `install-dir` requires sudo privs. The reason for this is that always using `sudo` actually broke our `self-hosted` runners since the user the runner runs as doesn't have sudo privs by security design.

#### Ticket Link
Fixes https://github.com/sigstore/cosign-installer/issues/85

#### Release Note
```release-note
* adds `use-sudo` optional input which defaults to false
```
