### PR TITLE
Remove warning about signing GitHub OIDC Tokens being experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
+      id-token: write # needed for signing the images with GitHub OIDC Token
 
     name: Install Cosign and test presence in path
     steps:


### PR DESCRIPTION
#### Summary

Removes the experimental warning which seems to be outdated.
See sigstore/cosign-installer#120

#### Release Note

NONE

#### Documentation

NONE
