### PR TITLE
Update action example for keyless signing as xarg is not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ jobs:
         env:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
           TAGS: ${{ steps.docker_meta.outputs.tags }}
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+        run: cosign sign --yes ${TAGS}@${DIGEST}
 ```
 
 ### Optional Inputs


### PR DESCRIPTION
#### Summary

Remove xargs call in the keyless signing example as cosign now detects the non-interactive mode.

Fixes: #131 

#### Documentation

This is a doc change :)