### PR TITLE
bump cosign to default to release v2.1.0 and update docs

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Cosign
         uses: ./
         with:
-          cosign-release: 'v2.0.0'
+          cosign-release: 'v2.0.2'
       - name: Check install!
         run: cosign version
       - name: Check root directory

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This action currently supports GitHub-provided Linux, macOS and Windows runners 
 Add the following entry to your Github workflow YAML file:
 
 ```yaml
-uses: sigstore/cosign-installer@v3.0.5
+uses: sigstore/cosign-installer@v3.1.0
 with:
-  cosign-release: 'v2.0.2' # optional
+  cosign-release: 'v2.1.0' # optional
 ```
 
 Example using a pinned version:
@@ -30,9 +30,9 @@ jobs:
     name: Install Cosign
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.0.5
+        uses: sigstore/cosign-installer@v3.1.0
         with:
-          cosign-release: 'v2.0.2'
+          cosign-release: 'v2.1.0'
       - name: Check install!
         run: cosign version
 ```
@@ -49,7 +49,7 @@ jobs:
     name: Install Cosign
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.0.5
+        uses: sigstore/cosign-installer@v3.1.0
       - name: Check install!
         run: cosign version
 ```
@@ -73,7 +73,7 @@ jobs:
           go-version: '1.20'
           check-latest: true
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.0.5
+        uses: sigstore/cosign-installer@v3.1.0
         with:
           cosign-release: main
       - name: Check install!
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.0.5
+        uses: sigstore/cosign-installer@v3.1.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   cosign-release:
     description: 'cosign release version to be installed'
     required: false
-    default: 'v2.0.2'
+    default: 'v2.1.0'
   install-dir:
     description: 'Where to install the cosign binary'
     required: false
@@ -65,13 +65,13 @@ runs:
           esac
         }
 
-        bootstrap_version='v2.0.2'
-        bootstrap_linux_amd64_sha='dc641173cbda29ba48580cdde3f80f7a734f3b558a25e5950a4b19f522678c70'
-        bootstrap_linux_arm_sha='686ef6160889e84e5710505345b5b55cef0873907d0ef5954c837d9d647cf169'
-        bootstrap_linux_arm64_sha='517e96f9d036c4b77db01132cacdbef21e4266e9ad3a93e67773c590ba54e26f'
-        bootstrap_darwin_amd64_sha='0f51cbe19a315b919e87042f0485331821722ecb7fce22cc1b880ed4833fc8b0'
-        bootstrap_darwin_arm64_sha='55242a52ebca43dfb133d0fe26e11546bfa4571addd6852d782c119d74deade1'
-        bootstrap_windows_amd64_sha='782fcc768fca4dea9eb7464032de4b3e602f8d605b71bae686762e7622faa9ca'
+        bootstrap_version='v2.1.0'
+        bootstrap_linux_amd64_sha='c4fef1a4c7e49ce2006493b9aa894b28be247987959698b97de771c129cce8ea'
+        bootstrap_linux_arm_sha='baa86b94b826a09e7e76121298236b2bf3b88dd62574bd9fb89e4bdf28014ea2'
+        bootstrap_linux_arm64_sha='f795a6903daadf764a5092599bfe6945cedd7656bef37884a3049ac1a529266c'
+        bootstrap_darwin_amd64_sha='7ba6cf7a02a203e1978464f09551164ccacb9aefcfef8d3ec73e67af46417a91'
+        bootstrap_darwin_arm64_sha='c8ddd323d6b714105e4b05b48beba6b4f57c552464aefd4691d018bff6b4c362'
+        bootstrap_windows_amd64_sha='c34ac8208450bd81eed283e036ef324d76fe86b2de674ca357722ac2a9688fb5'
         cosign_executable_name=cosign
 
         trap "popd >/dev/null" EXIT


### PR DESCRIPTION
#### Summary
- bump cosign to default to release v2.1.0 and update docs