### PR TITLE
use RUNNER_TOOL_CACHE path to store cosign

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -53,6 +53,59 @@ jobs:
           fi
         shell: bash
 
+  test_cached_tool:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    permissions: {}
+    name: test if cosign is in the cache
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install Cosign first time
+        id: install-first
+        uses: ./
+        with:
+          cosign-release: 'v2.4.3'
+      - name: Check cache structure and first install output
+        shell: bash
+        run: |
+          echo "First install cache-hit output: ${{ steps.install-first.outputs.cache-hit }}"
+          if [[ "${{ steps.install-first.outputs.cache-hit }}" == "false" ]]; then
+            echo "✅ First install correctly reported cache-hit=false"
+          else
+            echo "❌ First install should have cache-hit=false"
+            exit 1
+          fi
+          echo "Checking cache after first install..."
+          ls -la $RUNNER_TOOL_CACHE/cosign/
+          ls -la $RUNNER_TOOL_CACHE/cosign/v2.4.3/
+          if [[ -f "$RUNNER_TOOL_CACHE/cosign/v2.4.3/${{ runner.arch }}/cosign" ]]; then
+            echo "✅ Cosign binary cached successfully"
+          else
+            echo "❌ Cosign binary not found in cache"
+            exit 1
+          fi
+      - name: Install Cosign again (should use cache)
+        id: install-second
+        uses: ./
+        with:
+          cosign-release: 'v2.4.3'
+      - name: Verify cache was used
+        shell: bash
+        run: |
+          echo "Second install cache-hit output: ${{ steps.install-second.outputs.cache-hit }}"
+          if [[ "${{ steps.install-second.outputs.cache-hit }}" == "true" ]]; then
+            echo "✅ Second install correctly used cache (cache-hit=true)"
+          else
+            echo "❌ Second install should have used cache (cache-hit=true)"
+            exit 1
+          fi
+          echo "Verifying cosign still works after cache hit..."
+          cosign version
+
   test_existing_release_action:
     # this does not run on macOS as the support for multi-arch was not added yet
     runs-on: ${{ matrix.os }}
@@ -289,3 +342,60 @@ jobs:
           cosign-release: 'main'
       - name: Check install!
         run: cosign version
+
+  test_cached_go_install:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    name: Test caching for go install cosign on ${{ matrix.os }} with go ${{ matrix.go_version }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: '1.24'
+          check-latest: true
+      - name: Install Cosign with go install (first time)
+        id: install-go-first
+        uses: ./
+        with:
+          cosign-release: 'main'
+      - name: Check cache structure and first go install output
+        shell: bash
+        run: |
+          echo "First go install cache-hit output: ${{ steps.install-go-first.outputs.cache-hit }}"
+          if [[ "${{ steps.install-go-first.outputs.cache-hit }}" == "false" ]]; then
+            echo "✅ First go install correctly reported cache-hit=false"
+          else
+            echo "❌ First go install should have cache-hit=false"
+            exit 1
+          fi
+          echo "Checking cache after first go install..."
+          ls -la $RUNNER_TOOL_CACHE/cosign/
+          ls -la $RUNNER_TOOL_CACHE/cosign/main/
+          # Verify binary exists in expected location
+          if [[ -f "$RUNNER_TOOL_CACHE/cosign/main/${{ runner.arch }}/cosign" ]]; then
+            echo "✅ Go-installed cosign binary cached successfully"
+          else
+            echo "❌ Go-installed cosign binary not found in cache"
+            exit 1
+          fi
+      - name: Install Cosign with go install again (should use cache)
+        id: install-go-second
+        uses: ./
+        with:
+          cosign-release: 'main'
+      - name: Verify go install cache was used
+        shell: bash
+        run: |
+          echo "Second go install cache-hit output: ${{ steps.install-go-second.outputs.cache-hit }}"
+          if [[ "${{ steps.install-go-second.outputs.cache-hit }}" == "true" ]]; then
+            echo "✅ Second go install correctly used cache (cache-hit=true)"
+          else
+            echo "❌ Second go install should have used cache (cache-hit=true)"
+            exit 1
+          fi
+          echo "Verifying cosign still works after go install cache hit..."
+          cosign version

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ The following optional inputs:
 | `install-dir` | directory to place the `cosign` binary into instead of the default (`$HOME/.cosign`). |
 | `use-sudo` | set to `true` if `install-dir` location requires sudo privs. Defaults to false. |
 
+### Outputs
+
+| Input | Description |
+| --- | --- |
+| `cache-hit` | Whether `cosign` was found in cache and installation was skipped. |
+
 ## Security
 
 Should you discover any security issues, please refer to Sigstore's [security

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ description: 'Installs cosign and includes it in your path'
 branding:
   icon: 'package'
   color: 'blue'
-# This is pinned to the last major release, we have to bump it for each action version.
+
 inputs:
   cosign-release:
     description: 'cosign release version to be installed'
@@ -14,18 +14,24 @@ inputs:
   install-dir:
     description: 'Where to install the cosign binary'
     required: false
-    default: '$HOME/.cosign'
   use-sudo:
     description: 'set to true if install-dir location requires sudo privs'
     required: false
     default: 'false'
+
+outputs:
+  cache-hit:
+    description: 'Whether cosign was found in cache and installation was skipped'
+    value: ${{ steps.installer.outputs.cache-hit }}
+
 runs:
   using: "composite"
   steps:
     # We verify the version against a SHA **in the published action itself**, not in the GCS bucket.
-    - shell: bash
+    - id: installer
+      shell: bash
       run: |
-        #!/bin/bash
+        #!/usr/bin/env bash
         # cosign install script
         shopt -s expand_aliases
         if [ -z "$NO_COLOR" ]; then
@@ -37,13 +43,33 @@ runs:
         fi
         set -e
 
-        mkdir -p ${{ inputs.install-dir }}
+        export install_dir="${{ inputs.install-dir }}"
+
+        if [[ ! -d "$RUNNER_TOOL_CACHE" ]]; then
+          echo "Cache directory '$RUNNER_TOOL_CACHE' does not exist" >&2
+          exit 1
+        fi
+
+        if [[ -z "${{ inputs.install-dir }}" ]]; then
+          export install_dir="$RUNNER_TOOL_CACHE/cosign/${{ inputs.cosign-release }}/${{ runner.arch }}"
+
+          if command -v "$install_dir/cosign" &> /dev/null; then
+              echo "Found Cosign in the cache $RUNNER_TOOL_CACHE"
+              echo "cache-hit=true" >> $GITHUB_OUTPUT
+              exit 0
+          fi
+        fi
+
+        # Set cache-hit to false since we're proceeding with installation
+        echo "cache-hit=false" >> $GITHUB_OUTPUT
+
+        mkdir -p "$install_dir"
 
         if [[ ${{ inputs.cosign-release }} == "main" ]]; then
           log_info "installing cosign via 'go install' from its main version"
           GOBIN=$(go env GOPATH)/bin
           go install github.com/sigstore/cosign/v2/cmd/cosign@main
-          ln -s $GOBIN/cosign ${{ inputs.install-dir}}/cosign
+          cp "$GOBIN/cosign" "$install_dir/cosign"
           exit 0
         fi
 
@@ -76,7 +102,7 @@ runs:
 
         trap "popd >/dev/null" EXIT
 
-        pushd ${{ inputs.install-dir }} > /dev/null
+        pushd $install_dir > /dev/null
 
         case ${{ runner.os }} in
           Linux|linux)
@@ -261,8 +287,19 @@ runs:
           log_info "Installation complete!"
         fi
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      run: echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
       shell: bash
+      run: |
+        if [[ -z "${{ inputs.install-dir }}" ]]; then
+          echo "$RUNNER_TOOL_CACHE/cosign/${{ inputs.cosign-release }}/${{ runner.arch }}" >> $GITHUB_PATH
+        else
+          echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
+        fi
+
     - if: ${{ runner.os == 'Windows' }}
-      run: echo "${{ inputs.install-dir }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       shell: pwsh
+      run: |
+        if ([string]::IsNullOrEmpty("${{ inputs.install-dir }}")) {
+          "$ENV:RUNNER_TOOL_CACHE\cosign\${{ inputs.cosign-release }}\${{ runner.arch }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        } else {
+          echo "${{ inputs.install-dir }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        }


### PR DESCRIPTION

#### Summary
use RUNNER_TOOL_CACHE path to store cosign

Fixes: #183 
