### PR TITLE
docs: fix registry from gcr.io to ghcr.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jobs:
 This action does not need any GitHub permission to run, however, if your workflow needs to update, create or perform any
 action against your repository, then you should change the scope of the permission appropriately.
 
-For example, if you are using the `gcr.io` as your registry to push the images you will need to give the `write` permission
+For example, if you are using the `ghcr.io` as your registry to push the images you will need to give the `write` permission
 to the `packages` scope.
 
 Example of a simple workflow:


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
In the README.md, there is a typo where gcr.io should be written as ghcr.io. I will correct this.

#### Release Note
NONE

#### Documentation
NONE
