### PR TITLE
chore: update default cosign-release to v3.0.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   cosign-release:
     description: 'cosign release version to be installed'
     required: false
-    default: 'v3.0.3'
+    default: 'v3.0.5'
   install-dir:
     description: 'Where to install the cosign binary'
     required: false


### PR DESCRIPTION
#### Summary
Aligns the default cosign-release input with the bootstrap version, otherwise performs unnecessary fetch.

#### Release Note
* Updates default cosign-release to v3.0.5

#### Documentation
N/A
