### PR TITLE
Add support for riscv64 architecture

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -140,6 +140,12 @@ runs:
                 desired_cosign_filename='cosign-linux-arm64'
                 ;;
 
+              RISCV64|riscv64)
+                bootstrap_filename='cosign-linux-riscv64'
+                bootstrap_sha=${bootstrap_linux_riscv64_sha}
+                desired_cosign_filename='cosign-linux-riscv64'
+                ;;
+
               *)
                 log_error "unsupported architecture ${runner_arch}"
                 exit 1


### PR DESCRIPTION
Upstream cosign offers riscv64 binaries for download, and so let's add support for the riscv64 architecture in cosign-installer.

#### Summary

RISE RISC-V runners are generally available now, similar to self-hosted runners. So while GitHub itself does not (yet) have RISC-V Tier-1 runners it is now likely that cosign-installer GitHub Action would be called "in the wild" for RISC-V architecture.

#### Release Note
RISC-V support only for Linux; Not applicable to MacOS and Windows

#### Documentation
Unsure if this needs to be documented further.

Resolves: #228 