### PR TITLE
Import cosign_checksum.txt and parse with jq for cosign bootstrap env setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,94 +99,84 @@ runs:
           esac
         }
 
-        ## curl -sL https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign_checksums.txt |\
-        ##   gawk 'match($2,/^cosign-([[:alnum:]]+)-([[:alnum:]]+)(\.[[:alnum:]]+)?$/,a){printf "bootstrap_%s_%s_sha=\"%s\"\n",a[1],a[2],$1}' |\
-        ##   LANG=C sort
         bootstrap_version='v3.0.6'
-        bootstrap_darwin_amd64_sha="4c3e7af8372d3ca3296e62fa56f23fcbb5721cc6ac1827900d398f110d7cd280"
-        bootstrap_darwin_arm64_sha="5fadd012ae6381a6a29ff86a7d39aa873878852f1073fc90b15995961ecfb084"
-        bootstrap_linux_amd64_sha="c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"
-        bootstrap_linux_arm64_sha="bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8"
-        bootstrap_linux_arm_sha="67bd25d32daff5664caf51208c95defcb2ad7ac1296f394fa677bb8bacee62f5"
-        bootstrap_linux_ppc64le_sha="08c3e5e0a09c440f49e9a69d8639d37fbec522ec8c5c0ac805243b098e6ea512"
-        bootstrap_linux_riscv64_sha="e25952e798958b0f9168d044153ccc353f5469ca4b71a1707dffad0534d27017"
-        bootstrap_linux_s390x_sha="3cf4b769258ed9cc3c2a93268c0d5c1cc3fbd094af8df21035cbac8fb0d7c088"
-        bootstrap_windows_amd64_sha="9b85a88ebff2d9dd30ff4984a6f61f2cedc232dd87d81fa7f2ff3c0ed96c241c"
-
-        cosign_executable_name=cosign
+        ## curl -sL https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/cosign_checksums.txt
+        cat <<'EOF' > /tmp/cosign_checksums.txt
+        df8d6ab3d82bd3210c827bbe29f21c15988e0365f57111ced37190119e72ad78  cosign-3.0.6-1.aarch64.rpm
+        3e1c11beb777c81a6198642c742c215d997fa895b77423b3a4e68dc02324c51c  cosign-3.0.6-1.armv7hl.rpm
+        5d784fa78b11b66a7215f5ccb9c80a5db0d7e0aaf014f8048881ecc52ad27183  cosign-3.0.6-1.ppc64le.rpm
+        e82317de536850e234badc34de9e3e2cd77597d4583e0ec9f3ce4f361b32e28c  cosign-3.0.6-1.riscv64.rpm
+        66ebbe880c42043d4d79587539b4040e8cdac2f3934ef417e693062c0d81b21f  cosign-3.0.6-1.s390x.rpm
+        0efcd1a282138eefc8d762222dd45b5fe7c0adcee822a7164482480239f2bb92  cosign-3.0.6-1.x86_64.rpm
+        4c3e7af8372d3ca3296e62fa56f23fcbb5721cc6ac1827900d398f110d7cd280  cosign-darwin-amd64
+        0c30d292bad10aca12678c8d090ae76c713df2fc06eb905cfd0901522e0705d9  cosign-darwin-amd64_3.0.6_darwin_amd64.sbom.json
+        5fadd012ae6381a6a29ff86a7d39aa873878852f1073fc90b15995961ecfb084  cosign-darwin-arm64
+        c3f2acfc663f991c6e2196079896c2c1bb2fc9fa48e22377f12b8bfa19b46dc2  cosign-darwin-arm64_3.0.6_darwin_arm64.sbom.json
+        c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74  cosign-linux-amd64
+        1175014aab6ed44b05922899f952b63e04b195c32af1f92a56760f2d2de209bc  cosign-linux-amd64_3.0.6_linux_amd64.sbom.json
+        67bd25d32daff5664caf51208c95defcb2ad7ac1296f394fa677bb8bacee62f5  cosign-linux-arm
+        bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8  cosign-linux-arm64
+        6a79be71ec163b786c805234dc77bcb991762b0e984d4d50e870052b6ca1139d  cosign-linux-arm64_3.0.6_linux_arm64.sbom.json
+        e30f4502a4eb18f06367f764d12dd4391e367c6358e364482a946128722f7986  cosign-linux-arm_3.0.6_linux_arm.sbom.json
+        c1300d14ecb1db60abb494e2bbfdb4dd98cedbb8d86d79986557234773bee804  cosign-linux-pivkey-pkcs11key-amd64
+        da7b5af1c6e74c27e9316a029245acbe6d122ccdc2226e2099a06c8203bde8d5  cosign-linux-pivkey-pkcs11key-amd64_3.0.6_linux_amd64.sbom.json
+        b605904f15607adf343e7433a9f4fc0332739b237b657edd0fb175e9f418272f  cosign-linux-pivkey-pkcs11key-arm64
+        453b5b71f7fbc83631414ba6dc6eef794332d044ebe42e60d96e4922ea2068eb  cosign-linux-pivkey-pkcs11key-arm64_3.0.6_linux_arm64.sbom.json
+        08c3e5e0a09c440f49e9a69d8639d37fbec522ec8c5c0ac805243b098e6ea512  cosign-linux-ppc64le
+        d25c5d49c6cb85375cbd9a37c0e417f420acc190701cb573ebbf946031bc7013  cosign-linux-ppc64le_3.0.6_linux_ppc64le.sbom.json
+        e25952e798958b0f9168d044153ccc353f5469ca4b71a1707dffad0534d27017  cosign-linux-riscv64
+        ab132e20412be40dd62d5c14770ba9ef7923e5e12e7b98915aeddc8ce6fee74e  cosign-linux-riscv64_3.0.6_linux_riscv64.sbom.json
+        3cf4b769258ed9cc3c2a93268c0d5c1cc3fbd094af8df21035cbac8fb0d7c088  cosign-linux-s390x
+        19f590139b36de3793ea47d2376c9b6ef47522aae89bfa2dc703596fa70272ae  cosign-linux-s390x_3.0.6_linux_s390x.sbom.json
+        9b85a88ebff2d9dd30ff4984a6f61f2cedc232dd87d81fa7f2ff3c0ed96c241c  cosign-windows-amd64.exe
+        5f0248b0fa57a90898822aea7e35ed09016ed7424493c9aed0e63a9a4333a7c6  cosign-windows-amd64.exe_3.0.6_windows_amd64.sbom.json
+        6491b8e9d9b7a724e79f0d7db41ed1f8b64312419b8cd90926d874af7262fcdf  cosign_3.0.6_aarch64.apk
+        e16e8eb815f8b1b3cee3e678874393c286f19dd59e9ac5da95e428f970ef00f3  cosign_3.0.6_amd64.deb
+        93f382c7476e3effabff8a2c3561239381d55dc2b21b2ccbeaf70e460acfeaaa  cosign_3.0.6_arm64.deb
+        e67c52c352b44a0f05da884cd32970a4e07c8101fc2ba39ce82c47ecf66a2f08  cosign_3.0.6_armhf.deb
+        a2935deccd102d8a9235b95877e1c7f68d39302b32db07e9f94e179545ae4167  cosign_3.0.6_armv7.apk
+        c76c4e2b49046d253727a3167cd645f1eea036f662b87af7f410d0bf8b72a4f3  cosign_3.0.6_ppc64el.deb
+        5d47b90e16b6fd0db3d2b596d23c8b8a324f266d405ec8791d8dadd573332b35  cosign_3.0.6_ppc64le.apk
+        c9afbc64a4a8fcea99b3b94cbcf8e13a459e91f5ecb5d2212c10d078e54a468a  cosign_3.0.6_riscv64.apk
+        0d0175afcf645339012c0a3f6d928b40fde4ec3d9e364d8e85d70ad0cd53279f  cosign_3.0.6_riscv64.deb
+        7daefd6c95fde811039473d572b85740b4497f56a41b4484954a0edf821981ee  cosign_3.0.6_s390x.apk
+        290bae22c19a90ae17eadc2d4ddefc6da6e68516661246ae32822e831cdcef4a  cosign_3.0.6_s390x.deb
+        6962ebf3288c10340d5ee59dc17b511b95f3446f330bbd7adf23ccbde9515ae4  cosign_3.0.6_x86_64.apk
+        EOF
 
         trap "popd >/dev/null" EXIT
 
         pushd "${install_dir}" > /dev/null
 
-        case ${runner_os} in
-          Linux|linux)
-            case ${runner_arch} in
-              X64|amd64)
-                bootstrap_filename='cosign-linux-amd64'
-                bootstrap_sha=${bootstrap_linux_amd64_sha}
-                desired_cosign_filename='cosign-linux-amd64'
-                ;;
+        rejson='
+        {
+          "os": {
+            "darwin":   "macOS|macos"
+          },
+          "arch": {
+            "amd64":    "X64|amd64"
+          },
+          "env": {
+            "windows": {
+              "amd64": { "cosign_executable_name": "cosign.exe" }
+            }
+          }
+        }
+        '
 
-              ARM|arm)
-                bootstrap_filename='cosign-linux-arm'
-                bootstrap_sha=${bootstrap_linux_arm_sha}
-                desired_cosign_filename='cosign-linux-arm'
-                ;;
-
-              ARM64|arm64)
-                bootstrap_filename='cosign-linux-arm64'
-                bootstrap_sha=${bootstrap_linux_arm64_sha}
-                desired_cosign_filename='cosign-linux-arm64'
-                ;;
-
-              *)
-                log_error "unsupported architecture ${runner_arch}"
-                exit 1
-                ;;
-            esac
-            ;;
-
-          macOS|macos)
-            case ${runner_arch} in
-              X64|amd64)
-                bootstrap_filename='cosign-darwin-amd64'
-                bootstrap_sha=${bootstrap_darwin_amd64_sha}
-                desired_cosign_filename='cosign-darwin-amd64'
-                ;;
-
-              ARM64|arm64)
-                bootstrap_filename='cosign-darwin-arm64'
-                bootstrap_sha=${bootstrap_darwin_arm64_sha}
-                desired_cosign_filename='cosign-darwin-arm64'
-                ;;
-
-              *)
-                log_error "unsupported architecture ${runner_arch}"
-                exit 1
-                ;;
-            esac
-            ;;
-
-          Windows|windows)
-            case ${runner_arch} in
-              X64|amd64)
-                bootstrap_filename='cosign-windows-amd64.exe'
-                bootstrap_sha=${bootstrap_windows_amd64_sha}
-                desired_cosign_filename='cosign-windows-amd64.exe'
-                cosign_executable_name=cosign.exe
-                ;;
-              *)
-                log_error "unsupported architecture ${runner_arch}"
-                exit 1
-                ;;
-            esac
-            ;;
-          *)
-            log_error "unsupported os ${runner_os}"
-            exit 1
-            ;;
-        esac
+        jq --raw-output --argjson re "${rejson}" --arg runner_os "${runner_os}" --arg runner_arch "${runner_arch}" --raw-input '
+        [inputs]|map(capture("(?<sha>[[:xdigit:]]+)  (?<filename>.+)$")) as $cosign_checksums |
+        ($re.os | to_entries | map(.value as $regex | select($runner_os | test("^(\($regex))$"))|.key) | first // "\($runner_os|ascii_downcase)") as $os_match |
+        ($re.arch | to_entries | map(.value as $regex | select($runner_arch | test("^(\($regex))$"))|.key) | first // "\($runner_arch|ascii_downcase)") as $arch_match |
+        ($cosign_checksums | map(select(.filename|test("^cosign-\($os_match)-\($arch_match)(.([[:alnum:]]+))?$"))) | first) as $fileinfo |
+        $re.env."\($os_match)"."\($arch_match)" as $env |
+        { "bootstrap_filename": "\($fileinfo.filename // "")",
+          "bootstrap_sha": "\($fileinfo.sha // "")",
+          "desired_cosign_filename": "\($fileinfo.filename // "")",
+          "cosign_executable_name": "\($env.cosign_executable_name // "cosign")"
+        } | to_entries | map("\(.key)=\"\(.value)\"") | join("\n")
+        ' < /tmp/cosign_checksums.txt | tee /tmp/bootstrap.env
+        source /tmp/bootstrap.env
 
         SUDO=
         if [[ "${input_use_sudo}" == "true" ]] && command -v sudo >/dev/null; then


### PR DESCRIPTION

Streamline the cosign version bump process by importing cosign_checksum.txt as a heredoc, validate inputs with jq regex, and output variables.

Side-effect is this allows support for all OS and ARCHITECTURE releases published by upstream cosign. Adds a configuration JSON formatted snippet for env overrides on valid release filenames, by OS and ARCHITECTURE. If either OS or ARCHITECTURE are not matched in the configuration then assume to use ascii_downcase processed runner OS and runner ARCHITECTURE names to match within cosign_checksums.txt data.

Resolves: #228
Resolves: #233