### PR TITLE
Add RUNNER_TOOL_CACHE support to cache cosign binaries

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -253,3 +253,84 @@ jobs:
           cosign-release: 'main'
       - name: Check install!
         run: cosign version
+
+  test_tool_cache:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    permissions:
+      contents: read
+    name: Test tool cache on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install cosign with tool cache (first run)
+        id: install-first
+        uses: ./
+        with:
+          cosign-release: 'v3.0.5'
+          use-tool-cache: 'true'
+      - name: Verify first install reports cache miss and binary works
+        shell: bash
+        run: |
+          if [[ "${{ steps.install-first.outputs.cache-hit }}" == "false" ]]; then
+            echo "First install correctly reported cache-hit=false"
+          else
+            echo "First install should report cache-hit=false"
+            exit 1
+          fi
+          cosign version
+      - name: Install cosign with tool cache again (should hit cache)
+        id: install-second
+        uses: ./
+        with:
+          cosign-release: 'v3.0.5'
+          use-tool-cache: 'true'
+      - name: Verify second install uses cache and binary still works
+        shell: bash
+        run: |
+          if [[ "${{ steps.install-second.outputs.cache-hit }}" == "true" ]]; then
+            echo "Second install correctly reported cache-hit=true"
+          else
+            echo "Second install should report cache-hit=true"
+            exit 1
+          fi
+          cosign version
+
+  test_tool_cache_tamper_detection:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: Test tool cache rejects tampered binary
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install cosign with tool cache
+        uses: ./
+        with:
+          cosign-release: 'v3.0.5'
+          use-tool-cache: 'true'
+      - name: Tamper with cached binary to simulate cache poisoning
+        shell: bash
+        run: |
+          echo "tampered" > "$RUNNER_TOOL_CACHE/cosign/v3.0.5/${{ runner.arch }}/cosign"
+      - name: Re-install cosign (tampered cache should be rejected)
+        id: install-after-tamper
+        uses: ./
+        with:
+          cosign-release: 'v3.0.5'
+          use-tool-cache: 'true'
+      - name: Verify tampered cache was rejected and binary is valid
+        shell: bash
+        run: |
+          if [[ "${{ steps.install-after-tamper.outputs.cache-hit }}" == "false" ]]; then
+            echo "Tampered cache correctly rejected (cache-hit=false)"
+          else
+            echo "Expected tampered cache to be rejected (cache-hit=false)"
+            exit 1
+          fi
+          cosign version

--- a/README.md
+++ b/README.md
@@ -166,8 +166,15 @@ The following optional inputs:
 | Input | Description |
 | --- | --- |
 | `cosign-release` | `cosign` version to use instead of the default. |
-| `install-dir` | directory to place the `cosign` binary into instead of the default (`$HOME/.cosign`). |
+| `install-dir` | directory to place the `cosign` binary into instead of the default (`$HOME/.cosign`). Ignored when `use-tool-cache` is `true`. |
 | `use-sudo` | set to `true` if `install-dir` location requires sudo privs. Defaults to false. |
+| `use-tool-cache` | set to `true` to cache the `cosign` binary in `$RUNNER_TOOL_CACHE` for reuse across runs. On a cache hit, the binary's checksum is re-verified against the value stored during the original install before use. Defaults to false. |
+
+### Outputs
+
+| Output | Description |
+| --- | --- |
+| `cache-hit` | Set to `true` when `cosign` was found in the tool cache and installation was skipped. Only meaningful when `use-tool-cache` is `true`. |
 
 ## Security
 

--- a/action.yml
+++ b/action.yml
@@ -19,22 +19,29 @@ inputs:
     description: 'set to true if install-dir location requires sudo privs'
     required: false
     default: 'false'
+  use-tool-cache:
+    description: 'Cache the cosign binary in $RUNNER_TOOL_CACHE for reuse across runs. When enabled, install-dir is ignored.'
+    required: false
+    default: 'false'
+outputs:
+  cache-hit:
+    description: 'Whether cosign was found in the tool cache and installation was skipped (only meaningful when use-tool-cache is true)'
+    value: ${{ steps.installer.outputs.cache-hit }}
 runs:
   using: "composite"
   steps:
     # We verify the version against a SHA **in the published action itself**, not in the GCS bucket.
-    - shell: bash
+    - id: installer
+      shell: bash
       env:
         input_cosign_release: ${{ inputs.cosign-release }}
         input_install_dir: ${{ inputs.install-dir }}
         input_use_sudo: ${{ inputs.use-sudo }}
+        input_use_tool_cache: ${{ inputs.use-tool-cache }}
         runner_arch: ${{ runner.arch }}
         runner_os: ${{ runner.os }}
       run: |
         #!/bin/bash
-        # Substitute environment variables in install-dir input
-        install_dir=$(envsubst <<<"${input_install_dir}")
-
         # cosign install script
         shopt -s expand_aliases
         if [ -z "$NO_COLOR" ]; then
@@ -55,32 +62,6 @@ runs:
             [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" == "$1" ]
         }
 
-        # Check for unsupported old versions (anything below v2.0.0)
-        if [[ "${input_cosign_release}" != "main" ]]; then
-          # Extract version without 'v' prefix for comparison
-          version_num="${input_cosign_release}"
-          version_num="${version_num#v}"
-
-          # Check if version is less than v2.0.0
-          if ! is_version_ge "2.0.0" "$version_num"; then
-            log_error "cosign versions below v2.0.0 are no longer supported."
-            log_error "Requested version: ${input_cosign_release}"
-            log_error "Please use cosign v2.6.0 or later."
-            log_error "See https://github.com/sigstore/cosign/releases for available versions."
-            exit 1
-          fi
-        fi
-
-        mkdir -p "${install_dir}"
-
-        if [[ "${input_cosign_release}" == "main" ]]; then
-          log_info "installing cosign via 'go install' from its main version"
-          GOBIN=$(go env GOPATH)/bin
-          go install github.com/sigstore/cosign/v3/cmd/cosign@main
-          ln -s "$GOBIN/cosign" "${install_dir}/cosign"
-          exit 0
-        fi
-
         shaprog() {
           case ${runner_os} in
             Linux|linux)
@@ -99,6 +80,25 @@ runs:
           esac
         }
 
+        # Substitute environment variables in install-dir input
+        install_dir=$(envsubst <<<"${input_install_dir}")
+
+        # Check for unsupported old versions (anything below v2.0.0)
+        if [[ "${input_cosign_release}" != "main" ]]; then
+          # Extract version without 'v' prefix for comparison
+          version_num="${input_cosign_release}"
+          version_num="${version_num#v}"
+
+          # Check if version is less than v2.0.0
+          if ! is_version_ge "2.0.0" "$version_num"; then
+            log_error "cosign versions below v2.0.0 are no longer supported."
+            log_error "Requested version: ${input_cosign_release}"
+            log_error "Please use cosign v2.6.0 or later."
+            log_error "See https://github.com/sigstore/cosign/releases for available versions."
+            exit 1
+          fi
+        fi
+
         ## curl -sL https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign_checksums.txt |\
         ##   gawk 'match($2,/^cosign-([[:alnum:]]+)-([[:alnum:]]+)(\.[[:alnum:]]+)?$/,a){printf "bootstrap_%s_%s_sha=\"%s\"\n",a[1],a[2],$1}' |\
         ##   LANG=C sort
@@ -114,10 +114,6 @@ runs:
         bootstrap_windows_amd64_sha="9b85a88ebff2d9dd30ff4984a6f61f2cedc232dd87d81fa7f2ff3c0ed96c241c"
 
         cosign_executable_name=cosign
-
-        trap "popd >/dev/null" EXIT
-
-        pushd "${install_dir}" > /dev/null
 
         case ${runner_os} in
           Linux|linux)
@@ -188,6 +184,61 @@ runs:
             ;;
         esac
 
+        # Tool cache support: check for a previously verified binary before downloading
+        if [[ "${input_use_tool_cache}" == "true" ]]; then
+          if [[ -z "${RUNNER_TOOL_CACHE}" ]]; then
+            log_error "use-tool-cache is enabled but RUNNER_TOOL_CACHE is not set"
+            exit 1
+          fi
+
+          cache_dir="${RUNNER_TOOL_CACHE}/cosign/${input_cosign_release}/${runner_arch}"
+          cached_binary="${cache_dir}/${cosign_executable_name}"
+
+          if [[ -f "${cached_binary}" ]]; then
+            cached_sha=$(shaprog "${cached_binary}")
+            cache_valid=false
+
+            if [[ "${input_cosign_release}" == "${bootstrap_version}" ]] && [[ "${cached_sha}" == "${bootstrap_sha}" ]]; then
+              # Bootstrap version: compare against the hardcoded SHA embedded in this action
+              cache_valid=true
+            elif [[ -f "${cache_dir}/cosign.sha256" ]]; then
+              # Other versions: compare against the SHA stored during the previous verified install
+              expected_sha=$(cat "${cache_dir}/cosign.sha256")
+              if [[ "${cached_sha}" == "${expected_sha}" ]]; then
+                cache_valid=true
+              else
+                log_info "Cached cosign checksum mismatch, re-downloading"
+              fi
+            fi
+
+            if [[ "${cache_valid}" == "true" ]]; then
+              log_info "Cache hit! Using verified cosign ${input_cosign_release} from ${cache_dir}"
+              echo "cache-hit=true" >> "${GITHUB_OUTPUT}"
+              echo "COSIGN_INSTALL_PATH=${cache_dir}" >> "${GITHUB_ENV}"
+              exit 0
+            fi
+          fi
+
+          # Cache miss — install into the tool cache directory
+          install_dir="${cache_dir}"
+        fi
+
+        echo "cache-hit=false" >> "${GITHUB_OUTPUT}"
+        echo "COSIGN_INSTALL_PATH=${install_dir}" >> "${GITHUB_ENV}"
+
+        mkdir -p "${install_dir}"
+
+        if [[ "${input_cosign_release}" == "main" ]]; then
+          log_info "installing cosign via 'go install' from its main version"
+          GOBIN=$(go env GOPATH)/bin
+          go install github.com/sigstore/cosign/v3/cmd/cosign@main
+          cp "$GOBIN/cosign" "${install_dir}/cosign"
+          if [[ "${input_use_tool_cache}" == "true" ]]; then
+            shaprog "${install_dir}/cosign" > "${install_dir}/cosign.sha256"
+          fi
+          exit 0
+        fi
+
         SUDO=
         if [[ "${input_use_sudo}" == "true" ]] && command -v sudo >/dev/null; then
           SUDO=sudo
@@ -195,6 +246,11 @@ runs:
 
         expected_bootstrap_version_digest=${bootstrap_sha}
         log_info "Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed...\n      https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/${bootstrap_filename}"
+
+        trap "popd >/dev/null" EXIT
+
+        pushd "${install_dir}" > /dev/null
+
         $SUDO curl --retry "${CURL_RETRIES}" -fsSL "https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/${bootstrap_filename}" -o "${cosign_executable_name}"
         shaBootstrap=$(shaprog "${cosign_executable_name}")
         if [[ "$shaBootstrap" != "${expected_bootstrap_version_digest}" ]]; then
@@ -206,6 +262,9 @@ runs:
         # If the bootstrap and specified `cosign` releases are the same, we're done.
         if [[ "${input_cosign_release}" == "${bootstrap_version}" ]]; then
           log_info "bootstrap version successfully verified and matches requested version so nothing else to do"
+          if [[ "${input_use_tool_cache}" == "true" ]]; then
+            echo "${expected_bootstrap_version_digest}" > cosign.sha256
+          fi
           exit 0
         fi
 
@@ -266,19 +325,19 @@ runs:
           $SUDO rm "${cosign_executable_name}"
           $SUDO mv "cosign_${input_cosign_release}" "${cosign_executable_name}"
           $SUDO chmod +x "${cosign_executable_name}"
+
+          if [[ "${input_use_tool_cache}" == "true" ]]; then
+            shaprog "${cosign_executable_name}" > cosign.sha256
+          fi
+
           log_info "Installation complete!"
         fi
 
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       shell: bash
-      env:
-        input_install_dir: ${{ inputs.install-dir }}
-      run: envsubst <<<"${input_install_dir}" >> "$GITHUB_PATH"
+      run: echo "${COSIGN_INSTALL_PATH}" >> "$GITHUB_PATH"
 
     - if: ${{ runner.os == 'Windows' }}
       shell: pwsh
-      env:
-        input_install_dir: ${{ inputs.install-dir }}
       run: |
-        $install_dir = $ExecutionContext.InvokeCommand.ExpandString("${env:input_install_dir}")
-        echo "${install_dir}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $env:COSIGN_INSTALL_PATH | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append


### PR DESCRIPTION
#### Summary

Resolves #183 by adding RUNNER_TOOL_CACHE support. There was a previous PR, so I leveraged both its changes and 

#### Release Note

* Adds `RUNNER_TOOL_CACHE` support support to cache and validate cosign binaries

#### Documentation

Good question. The cache does require an opt-in, so might be worth including in some documentation somewhere.

#### AI Disclaimer

I did use AI to help produce this PR, but did manually validate the changes. 

Additionally, the agent provided the following description:

---

## Summary

Adds a `use-tool-cache` input that caches the cosign binary in `$RUNNER_TOOL_CACHE` for reuse across runs. This is particularly useful for self-hosted runners with restricted or expensive network access, and for workshop/lab environments where the same binary is installed repeatedly.

## What changed

**`action.yml`**
- New `use-tool-cache` input (default: `'false'`). When enabled, `install-dir` is ignored and the binary is stored at `$RUNNER_TOOL_CACHE/cosign/<version>/<arch>/`.
- New `cache-hit` output — `'true'` when the cached binary passed verification and the download was skipped.
- On a cache hit, the cached binary's checksum is re-verified before use:
  - **Bootstrap version** (`v3.0.6`): compared against the hardcoded SHA embedded in the action itself, providing tamper-detection without any network access.
  - **Other versions**: compared against a `cosign.sha256` sidecar file written to the cache directory during the original cryptographically-verified install. A mismatch triggers a full re-download and re-verification.
- A `cosign.sha256` sidecar is written after every successful verified install (bootstrap, custom, and `go install` paths).
- Backwards-compatible: the default behaviour (`install-dir: $HOME/.cosign`, no caching) is unchanged.

**`README.md`**: Documents the new input and output.

**`test-action.yml`**: Two new CI jobs:
- `test_tool_cache` — cross-platform (Linux, macOS, Windows); asserts `cache-hit=false` on first install and `cache-hit=true` on the second.
- `test_tool_cache_tamper_detection` — installs cosign, overwrites the cached binary with garbage to simulate cache poisoning, re-runs the action, and asserts `cache-hit=false` (the tampered binary is rejected and cosign is re-downloaded and re-verified).

## Security notes

The checksum stored in `cosign.sha256` is derived from a cryptographically verified install (keyless/KMS signature via cosign verify-blob), so it reflects a known-good binary. A cache-poisoning attempt that replaces only the binary will be caught by the checksum mismatch and trigger a fresh download. Replacing both the binary and the sidecar file requires write access to `$RUNNER_TOOL_CACHE`; on GitHub-hosted runners each job gets a fresh VM, so this is not a concern. On self-hosted runners, administrators are assumed to control the cache directory — the same trust model used by all other GitHub Actions tool-cache integrations (e.g. `actions/setup-go`).
