### PR TITLE
fix: harden curl download retries against transient GitHub CDN 504s

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The following optional inputs:
 | `cosign-release` | `cosign` version to use instead of the default. |
 | `install-dir` | directory to place the `cosign` binary into instead of the default (`$HOME/.cosign`). |
 | `use-sudo` | set to `true` if `install-dir` location requires sudo privs. Defaults to false. |
+| `curl-retries` | number of times to retry each download on transient network failures (e.g. GitHub CDN 504s). Defaults to 6. |
 
 ## Security
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'set to true if install-dir location requires sudo privs'
     required: false
     default: 'false'
+  curl-retries:
+    description: 'number of times to retry each download on transient network failures (e.g. GitHub CDN 504s)'
+    required: false
+    default: '6'
 runs:
   using: "composite"
   steps:
@@ -28,6 +32,7 @@ runs:
         input_cosign_release: ${{ inputs.cosign-release }}
         input_install_dir: ${{ inputs.install-dir }}
         input_use_sudo: ${{ inputs.use-sudo }}
+        input_curl_retries: ${{ inputs.curl-retries }}
         runner_arch: ${{ runner.arch }}
         runner_os: ${{ runner.os }}
       run: |
@@ -46,7 +51,13 @@ runs:
         fi
         set -e
 
-        CURL_RETRIES=3
+        CURL_RETRIES="${input_curl_retries:-6}"
+        # Retry options shared by every release download below. GitHub's release
+        # CDN intermittently returns transient HTTP 504s that can persist for
+        # ~15-20s, outlasting curl's default exponential backoff (~7s across 3
+        # retries). A fixed 5s delay with --retry-all-errors rides out those
+        # windows, while --retry-max-time 120 keeps a failing download bounded.
+        CURL_RETRY_OPTS=(--retry "${CURL_RETRIES}" --retry-delay 5 --retry-all-errors --retry-max-time 120)
 
         # This function helps compare versions.
         # Returns 0 if version1 >= version2, 1 otherwise.
@@ -195,7 +206,7 @@ runs:
 
         expected_bootstrap_version_digest=${bootstrap_sha}
         log_info "Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed...\n      https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/${bootstrap_filename}"
-        $SUDO curl --retry "${CURL_RETRIES}" -fsSL "https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/${bootstrap_filename}" -o "${cosign_executable_name}"
+        $SUDO curl "${CURL_RETRY_OPTS[@]}" -fsSL "https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/${bootstrap_filename}" -o "${cosign_executable_name}"
         shaBootstrap=$(shaprog "${cosign_executable_name}")
         if [[ "$shaBootstrap" != "${expected_bootstrap_version_digest}" ]]; then
           log_error "Unable to validate cosign version: '${input_cosign_release}'"
@@ -219,7 +230,7 @@ runs:
 
         # Download custom cosign
         log_info "Downloading platform-specific version '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${desired_cosign_filename}"
-        $SUDO curl --retry "${CURL_RETRIES}" -fsSL "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${desired_cosign_filename}" -o "cosign_${input_cosign_release}"
+        $SUDO curl "${CURL_RETRY_OPTS[@]}" -fsSL "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${desired_cosign_filename}" -o "cosign_${input_cosign_release}"
         shaCustom=$(shaprog "cosign_${input_cosign_release}");
 
         # same hash means it is the same release
@@ -229,7 +240,7 @@ runs:
           RELEASE_COSIGN_PUB_KEY_SHA='f4cea466e5e887a45da5031757fa1d32655d83420639dc1758749b744179f126'
 
           log_info "Verifying public key matches expected value"
-          $SUDO curl --retry "${CURL_RETRIES}" -fsSL "$RELEASE_COSIGN_PUB_KEY" -o public.key
+          $SUDO curl "${CURL_RETRY_OPTS[@]}" -fsSL "$RELEASE_COSIGN_PUB_KEY" -o public.key
           sha_fetched_key=$(shaprog public.key)
           if [[ "$sha_fetched_key" != "$RELEASE_COSIGN_PUB_KEY_SHA" ]]; then
             log_error "Fetched public key does not match expected digest, exiting"
@@ -240,7 +251,7 @@ runs:
             # we're trying to get something greater than or equal to v3.0.1
             keyless_signature_file=${desired_cosign_filename}.sigstore.json
             log_info "Downloading keyless verification bundle for platform-specific '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${keyless_signature_file}"
-            $SUDO curl --retry "${CURL_RETRIES}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${keyless_signature_file}"
+            $SUDO curl "${CURL_RETRY_OPTS[@]}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${keyless_signature_file}"
 
             log_info "Using bootstrap cosign to verify keyless signature of desired cosign version"
             "./${cosign_executable_name}" verify-blob --certificate-identity=keyless@projectsigstore.iam.gserviceaccount.com --certificate-oidc-issuer=https://accounts.google.com --bundle "${keyless_signature_file}" "cosign_${input_cosign_release}"
@@ -249,7 +260,7 @@ runs:
               # we're trying to get something greater than or equal to v3.0.3
               kms_signature_file=${desired_cosign_filename}-kms.sigstore.json
               log_info "Downloading KMS verification bundle for platform-specific '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${kms_signature_file}"
-              $SUDO curl --retry "${CURL_RETRIES}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${kms_signature_file}"
+              $SUDO curl "${CURL_RETRY_OPTS[@]}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${kms_signature_file}"
 
               log_info "Using bootstrap cosign to verify signature of desired cosign version"
               "./${cosign_executable_name}" verify-blob --key public.key --bundle "${kms_signature_file}" "cosign_${input_cosign_release}"
@@ -257,7 +268,7 @@ runs:
           else
             signature_file=${desired_cosign_filename}.sig
             log_info "Downloading detached signature for platform-specific '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${signature_file}"
-            $SUDO curl --retry "${CURL_RETRIES}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${signature_file}"
+            $SUDO curl "${CURL_RETRY_OPTS[@]}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${signature_file}"
 
             log_info "Using bootstrap cosign to verify signature of desired cosign version"
             "./${cosign_executable_name}" verify-blob --key public.key --signature "${signature_file}" "cosign_${input_cosign_release}"


### PR DESCRIPTION
## Summary
- `--retry 3` (added in #210 for #209) gives up after only ~7s with curl's default exponential backoff (1s + 2s + 4s), which is too short for real GitHub release-CDN 504 windows.
- Make the retry count configurable via a new `curl-retries` input (default `6`), and add robust backoff — `--retry-delay 5 --retry-all-errors --retry-max-time 120` — to all six release downloads via a shared `CURL_RETRY_OPTS` array.
- All checksum and signature verification is unchanged.

## Why `--retry 3` is insufficient
#210 closed #209 by adding `curl --retry 3`. But with curl's default exponential backoff, 3 retries are exhausted after ~7s. Real `github.com/.../releases/download/...` gateway-timeout windows last longer.

On a version that **already includes #210**, we hit the bootstrap download (`cosign-linux-amd64`) returning HTTP 504 four times across an ~18s window; curl then exhausted its retries and the job died with `curl: (22) ... error: 504` (exit code 22).

## What changes
- New optional `curl-retries` input, default `6` (also honours a pre-set `CURL_RETRIES` env var).
- A shared `CURL_RETRY_OPTS=(--retry "${CURL_RETRIES}" --retry-delay 5 --retry-all-errors --retry-max-time 120)` applied to every curl call (bootstrap binary, target binary, public key, keyless/KMS bundles, detached signature).
- 6 retries at a fixed 5s delay cover ~30s of CDN flakiness — comfortably riding out the ~18s windows we observed — while `--retry-max-time 120` keeps a genuinely failing download bounded.

Effectively supersedes #209 / strengthens #210.