### PR TITLE
bump cosign and add support for additional platforms

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   cosign-release:
     description: 'cosign release version to be installed'
     required: false
-    default: 'v3.0.6'
+    default: 'v3.1.1'
   install-dir:
     description: 'Where to install the cosign binary'
     required: false
@@ -99,19 +99,19 @@ runs:
           esac
         }
 
-        ## curl -sL https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign_checksums.txt |\
+        ## curl -sL https://github.com/sigstore/cosign/releases/download/v3.1.1/cosign_checksums.txt |\
         ##   gawk 'match($2,/^cosign-([[:alnum:]]+)-([[:alnum:]]+)(\.[[:alnum:]]+)?$/,a){printf "bootstrap_%s_%s_sha=\"%s\"\n",a[1],a[2],$1}' |\
         ##   LANG=C sort
-        bootstrap_version='v3.0.6'
-        bootstrap_darwin_amd64_sha="4c3e7af8372d3ca3296e62fa56f23fcbb5721cc6ac1827900d398f110d7cd280"
-        bootstrap_darwin_arm64_sha="5fadd012ae6381a6a29ff86a7d39aa873878852f1073fc90b15995961ecfb084"
-        bootstrap_linux_amd64_sha="c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"
-        bootstrap_linux_arm64_sha="bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8"
-        bootstrap_linux_arm_sha="67bd25d32daff5664caf51208c95defcb2ad7ac1296f394fa677bb8bacee62f5"
-        bootstrap_linux_ppc64le_sha="08c3e5e0a09c440f49e9a69d8639d37fbec522ec8c5c0ac805243b098e6ea512"
-        bootstrap_linux_riscv64_sha="e25952e798958b0f9168d044153ccc353f5469ca4b71a1707dffad0534d27017"
-        bootstrap_linux_s390x_sha="3cf4b769258ed9cc3c2a93268c0d5c1cc3fbd094af8df21035cbac8fb0d7c088"
-        bootstrap_windows_amd64_sha="9b85a88ebff2d9dd30ff4984a6f61f2cedc232dd87d81fa7f2ff3c0ed96c241c"
+        bootstrap_version='v3.1.1'
+        bootstrap_darwin_amd64_sha="14d2678dfbfde18798151e86fbd91ebdadbb7424b18412a42a155dd8a2df4c7a"
+        bootstrap_darwin_arm64_sha="94b42a9e697be95675f6160ab031a9a5f1ec1e646d6f648d7b2f5cd59ececbc5"
+        bootstrap_linux_amd64_sha="ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc"
+        bootstrap_linux_arm64_sha="2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11"
+        bootstrap_linux_arm_sha="7a42f9eafc332b49f35f7ccf9959ba91a7a90fc010af2afacefc139259220d23"
+        bootstrap_linux_ppc64le_sha="1ec2d971b211da1d4bac2795c61d4041fb663d93fd98ebc2b87bdc0f067f547b"
+        bootstrap_linux_riscv64_sha="da91851b82d29e097385bc21cb2f2e449e284d7dae974e640d1f78ca0c33e722"
+        bootstrap_linux_s390x_sha="15433f2ac5f5be60e51538bce1f07c13b80f7b5ed474a247fd2159f7705dd871"
+        bootstrap_windows_amd64_sha="9d2c026e667bfd979fa7ba1cab8c4b24d2e73f336ec2d57f7fc72c7e73e5b4b6"
 
         cosign_executable_name=cosign
 
@@ -138,6 +138,24 @@ runs:
                 bootstrap_filename='cosign-linux-arm64'
                 bootstrap_sha=${bootstrap_linux_arm64_sha}
                 desired_cosign_filename='cosign-linux-arm64'
+                ;;
+
+              PPC64LE|ppc64le)
+                bootstrap_filename='cosign-linux-ppc64le'
+                bootstrap_sha=${bootstrap_linux_ppc64le_sha}
+                desired_cosign_filename='cosign-linux-ppc64le'
+                ;;
+
+              RISCV64|riscv64)
+                bootstrap_filename='cosign-linux-riscv64'
+                bootstrap_sha=${bootstrap_linux_riscv64_sha}
+                desired_cosign_filename='cosign-linux-riscv64'
+                ;;
+
+              S390X|s390x)
+                bootstrap_filename='cosign-linux-s390x'
+                bootstrap_sha=${bootstrap_linux_s390x_sha}
+                desired_cosign_filename='cosign-linux-s390x'
                 ;;
 
               *)


### PR DESCRIPTION
#### Summary

Prebuilt binaries are shipped by cosign for ppc64le, riscv64 and s390x.
Add support for these platforms in the action.

Bump cosign version at the same time