### PR TITLE
feat: add cosign-release-file input to read the cosign version from a file

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -119,6 +119,32 @@ jobs:
           fi
         shell: bash
 
+  test_cosign_action_version_file:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    permissions:
+      contents: read
+    name: Install Cosign from cosign-release-file on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Create version file
+        run: echo "cosign v3.0.5" > .tool-versions
+        shell: bash
+      - name: Install Cosign from version file
+        uses: ./
+        with:
+          cosign-release-file: ".tool-versions"
+      - name: Check install!
+        run: cosign version
+      - name: Check version matches file
+        run: cosign version 2>&1 | grep "3.0.5"
+        shell: bash
+
   test_unsupported_versions:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The following optional inputs:
 | Input | Description |
 | --- | --- |
 | `cosign-release` | `cosign` version to use instead of the default. |
+| `cosign-release-file` | path to a file containing the `cosign` version to use. Supports the asdf [`.tool-versions`](https://asdf-vm.com/manage/configuration.html#tool-versions) layout (the `cosign` entry) and plain version files. The version is used as-is, so include the leading `v` (for example `cosign v3.0.6`). Takes precedence over `cosign-release` when set. |
 | `install-dir` | directory to place the `cosign` binary into instead of the default (`$HOME/.cosign`). |
 | `use-sudo` | set to `true` if `install-dir` location requires sudo privs. Defaults to false. |
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: 'cosign release version to be installed'
     required: false
     default: 'v3.0.6'
+  cosign-release-file:
+    description: "path to a file containing the cosign release version (asdf '.tool-versions' or a plain version file; the version is used as-is, e.g. v3.0.6). Takes precedence over 'cosign-release' when set."
+    required: false
   install-dir:
     description: 'Where to install the cosign binary'
     required: false
@@ -26,6 +29,7 @@ runs:
     - shell: bash
       env:
         input_cosign_release: ${{ inputs.cosign-release }}
+        input_cosign_release_file: ${{ inputs.cosign-release-file }}
         input_install_dir: ${{ inputs.install-dir }}
         input_use_sudo: ${{ inputs.use-sudo }}
         runner_arch: ${{ runner.arch }}
@@ -54,6 +58,41 @@ runs:
         is_version_ge() {
             [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" == "$1" ]
         }
+
+        # Resolve the cosign version from a version file. Supports the asdf
+        # '.tool-versions' format (a line such as "cosign v3.0.6") as well as a
+        # plain file that contains only the version string.
+        resolve_version_from_file() {
+          local file="$1"
+          local version=""
+
+          if [[ ! -f "${file}" ]]; then
+            log_error "cosign-release-file '${file}' does not exist." >&2
+            exit 1
+          fi
+
+          # asdf '.tool-versions' format: a line such as "cosign v3.0.6".
+          version=$(grep -E '^[[:space:]]*cosign[[:space:]]+' "${file}" | head -n 1 | tr -d '\r' | awk '{print $2}') || true
+
+          # Otherwise treat the file as a plain version file (first token of the
+          # first non-empty, non-comment line).
+          if [[ -z "${version}" ]]; then
+            version=$(grep -vE '^[[:space:]]*(#|$)' "${file}" | head -n 1 | tr -d '\r' | awk '{print $1}') || true
+          fi
+
+          if [[ -z "${version}" ]]; then
+            log_error "no cosign version found in cosign-release-file '${file}'." >&2
+            exit 1
+          fi
+
+          echo "${version}"
+        }
+
+        # A version file takes precedence over the 'cosign-release' input when set.
+        if [[ -n "${input_cosign_release_file:-}" ]]; then
+          input_cosign_release="$(resolve_version_from_file "${input_cosign_release_file}")"
+          log_info "Using cosign version '${input_cosign_release}' from cosign-release-file '${input_cosign_release_file}'."
+        fi
 
         # Check for unsupported old versions (anything below v2.0.0)
         if [[ "${input_cosign_release}" != "main" ]]; then


### PR DESCRIPTION
Adds a `cosign-release-file` input that reads the cosign release version from a
file, so the version can live in a single source of truth (for example an asdf
`.tool-versions` file) instead of being hard-coded in the workflow.

- Supports the asdf `.tool-versions` layout (the `cosign` entry) and plain
  version files.
- The version is used as-is (include the leading `v`, e.g. `v3.0.6`),
  consistent with the existing `cosign-release` input; the `main` value is
  passed through unchanged.
- When both are set, `cosign-release-file` takes precedence over
  `cosign-release`.
- The resolved version flows through the existing bootstrap SHA + signature
  verification path unchanged, so there is no change to how releases are
  validated.

## Validation

- Added a `test_cosign_action_version_file` job (macOS, Ubuntu, Windows) that
  writes `cosign v3.0.5` to a `.tool-versions` file and asserts the installed
  cosign reports that version.
- Locally verified the resolver against a multi-tool `.tool-versions`, plain
  version files, comment/blank lines, the `main` value, and CRLF line endings,
  under both bash and zsh; `shellcheck` clean (`--severity=error`).
