### PR TITLE
test minimum of 1.26 given cosign requirement

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -236,7 +236,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         go_version:
-          - '1.25'
           - '1.26'
     name: Try to install cosign with go ${{ matrix.go_version }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
looks like cosign requires 1.26 now so stop testing with 1.25